### PR TITLE
Fail build if curl fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 ARG VERSION=3.27
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+RUN curl --create-dirs -fsSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 


### PR DESCRIPTION
curl should fail if http response code is between 401 and 407, otherwise it would create after an 404 the slave.jar with the html output of the error and the build would procceed and finish successfully