### PR TITLE
Stop shipping undocumented Windows image tags

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -23,11 +23,11 @@ if(![String]::IsNullOrWhiteSpace($env:DOCKERHUB_ORGANISATION)) {
 $builds = @{
     'jdk8' = @{
         'Folder' = '8\windows\windowsservercore-1809';
-        'Tags' = @( "latest", "windowsservercore-1809", "jdk8", "jdk8-windowsservercore-1809" )
+        'Tags' = @( "windowsservercore-1809", "jdk8-windowsservercore-1809" )
     };
     'jdk11' = @{
         'Folder' = '11\windows\windowsservercore-1809';
-        'Tags' = @( "jdk11-windowsservercore-1809", "jdk11" )
+        'Tags' = @( "jdk11-windowsservercore-1809" )
     };
     'nanoserver' = @{
         'Folder' = '8\windows\nanoserver-1809';


### PR DESCRIPTION
This change restricts deployments only to tags documented in https://github.com/jenkinsci/docker-agent#configurations . We should definitely start shipping short handles for Windows images later, but now it is needed to prevent collision of the `latest` tag.

Closes #125 