### PR TITLE
Remove stretch-backports from apt sources

### DIFF
--- a/8/buster/Dockerfile
+++ b/8/buster/Dockerfile
@@ -34,7 +34,6 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
 RUN apt-get update && apt-get install -t stretch-backports git-lfs && rm -rf /var/lib/apt/lists/*
 RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \

--- a/8/buster/Dockerfile
+++ b/8/buster/Dockerfile
@@ -34,7 +34,7 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN apt-get update && apt-get install -t stretch-backports git-lfs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install git-lfs && rm -rf /var/lib/apt/lists/*
 RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \


### PR DESCRIPTION
stretch-backports was brought in by https://github.com/jenkinsci/docker-agent/pull/61 to support the install of git-lfs which for buster is also in stable