### PR TITLE
Add openjdk11-alpine Dockerfile

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -1,0 +1,49 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+FROM adoptopenjdk/openjdk11:alpine
+
+ARG VERSION=4.3
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+RUN addgroup -g ${gid} ${group}
+RUN adduser -h /home/${user} -u ${uid} -G ${group} -D ${user}
+LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
+
+ARG AGENT_WORKDIR=/home/${user}/agent
+
+RUN apk add --update --no-cache curl bash git git-lfs openssh-client openssl procps \
+  && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+  && chmod 755 /usr/share/jenkins \
+  && chmod 644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
+  && apk del curl
+USER ${user}
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/${user}/.jenkins && mkdir -p ${AGENT_WORKDIR}
+
+VOLUME /home/${user}/.jenkins
+VOLUME ${AGENT_WORKDIR}
+WORKDIR /home/${user}

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ IMAGE_NAME:=jenkins4eval/agent
 IMAGE_NAME_AGENT:=jenkins4eval/slave
 
 .PHONY: build
-.PHONY: test test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-buster
+.PHONY: test test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-alpine test-jdk11-buster
 
-build: build-alpine build-debian build-debian-buster build-jdk11 build-jdk11-buster
+build: build-alpine build-debian build-debian-buster build-jdk11 build-jdk11-alpine build-jdk11-buster
 
 build-alpine:
 	docker build -t ${IMAGE_NAME}:alpine \
@@ -33,11 +33,18 @@ build-jdk11:
                  -t ${IMAGE_NAME}:jdk11-stretch \
                  11/stretch/
 
+build-jdk11-alpine:
+	docker build -t ${IMAGE_NAME}:alpine \
+                 -t ${IMAGE_NAME}:jdk11-alpine \
+                 -t ${IMAGE_NAME}:jdk11-alpine3.9 \
+                 -t ${IMAGE_NAME_AGENT}:alpine \
+                 11/alpine/
+
 build-jdk11-buster:
 	docker build -t ${IMAGE_NAME}:jdk11-buster \
-                -t ${IMAGE_NAME_AGENT}:jdk11-buster \
-                -t ${IMAGE_NAME_AGENT}:jdk11 \
-                11/buster/
+                 -t ${IMAGE_NAME_AGENT}:jdk11-buster \
+                 -t ${IMAGE_NAME_AGENT}:jdk11 \
+                 11/buster/
 
 bats:
 # The lastest version is v1.1.0
@@ -57,6 +64,9 @@ test-debian-buster: bats
 
 test-jdk11: bats
 	@FOLDER="11/stretch"  bats-core/bin/bats tests/tests.bats
+
+test-jdk11-alpine: bats
+	@FOLDER="11/alpine" bats-core/bin/bats tests/tests.bats
 
 test-jdk11-buster: bats
 	@FOLDER="11/buster"   bats-core/bin/bats tests/tests.bats


### PR DESCRIPTION
This PR adds a Dockerfile based on adoptopenjdk/openjdk11:alpine
inspired by the work from @slide in jenkinsci/docker