### PR TITLE
Add archlinux jdk11 Dockerfile

### DIFF
--- a/11/arch/Dockerfile
+++ b/11/arch/Dockerfile
@@ -1,0 +1,49 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+FROM archlinux:latest AS arch
+
+ARG VERSION=4.3
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+RUN groupadd -g ${gid} ${group}
+RUN useradd -c "Jenkins user" -d /home/${user} -u ${uid} -g ${gid} -m ${user}
+LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
+
+ARG AGENT_WORKDIR=/home/${user}/agent
+
+RUN pacman -Syu git jdk11-openjdk --noconfirm
+RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+  && chmod 755 /usr/share/jenkins \
+  && chmod 644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+
+USER ${user}
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/${user}/.jenkins && mkdir -p ${AGENT_WORKDIR}
+
+VOLUME /home/${user}/.jenkins
+VOLUME ${AGENT_WORKDIR}
+WORKDIR /home/${user}

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ IMAGE_NAME:=jenkins4eval/agent
 IMAGE_NAME_AGENT:=jenkins4eval/slave
 
 .PHONY: build
-.PHONY: test test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-alpine test-jdk11-buster
+.PHONY: test test-alpine test-arch test-debian test-debian-buster test-jdk11 test-jdk11-alpine test-jdk11-buster
 
-build: build-alpine build-debian build-debian-buster build-jdk11 build-jdk11-alpine build-jdk11-buster
+build: build-alpine build-arch build-debian build-debian-buster build-jdk11 build-jdk11-alpine build-jdk11-buster
 
 build-alpine:
 	docker build -t ${IMAGE_NAME}:alpine \
@@ -14,6 +14,12 @@ build-alpine:
                  -t ${IMAGE_NAME}:jdk8-alpine3.9 \
                  -t ${IMAGE_NAME_AGENT}:alpine \
                  8/alpine/
+
+build-arch:
+	docker build -t ${IMAGE_NAME}:latest \
+                 -t ${IMAGE_NAME}:arch \
+                 -t ${IMAGE_NAME}:jdk11-arch \
+                 11/arch/
 
 build-debian:
 	docker build -t ${IMAGE_NAME}:latest \
@@ -51,10 +57,13 @@ bats:
 	@if [ ! -d bats-core ]; then git clone https://github.com/bats-core/bats-core.git; fi
 	@git -C bats-core reset --hard c706d1470dd1376687776bbe985ac22d09780327
 
-test: test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-buster
+test: test-alpine test-arch test-debian test-debian-buster test-jdk11 test-jdk11-buster
 
 test-alpine: bats
 	@FOLDER="8/alpine" bats-core/bin/bats tests/tests.bats
+
+test-arch: bats
+	@FOLDER="11/arch" bats-core/bin/bats tests/tests.bats
 
 test-debian: bats
 	@FOLDER="8/stretch"   bats-core/bin/bats tests/tests.bats


### PR DESCRIPTION
add a dockerfile for arch linux to have a rolling release image with newest versions. can be made with openjdk14 or 15 if desired:
* https://www.archlinux.org/packages/extra/x86_64/jdk-openjdk/
* https://aur.archlinux.org/packages/java-openjdk-ea-bin/
