### PR TITLE
Switch the Alpine JDK8 image to AdoptOpenJDK

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -20,7 +20,10 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM openjdk:8-jdk-alpine3.9
+# FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
+# There is no official Alpine images at the moment.
+# Needs upgrade when/if there is an official alpine image.
+FROM adoptopenjdk/openjdk8:jdk8u262-b10-alpine
 
 ARG VERSION=4.3
 ARG user=jenkins

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The image has several supported configurations, which can be accessed via the fo
 * `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk-buster`)
 * `latest-stretch`: Latest version with the newest remoting (based on `openjdk:8-jdk-stretch`)
 * `latest-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11-jdk-buster`)
-* `alpine`: Small image based on Alpine Linux (based on `openjdk:8-jdk-alpine`)
+* `alpine`: Small image based on Alpine Linux (based on `adoptopenjdk/openjdk8:jdk8u${version}-alpine`)
 * `jdk8-windowsservercore-1809`: Latest version with the newest remoting (based on `adoptopenjdk:8-jdk-hotspot-windowsservercore-1809`)
 * `jdk11-windowsservercore-1809`: Latest version with the newest remoting and Java 11 (based on `adoptopenjdk:11-jdk-hotspot-windowsservercore-1809`)
 * `jdk8-nanoserver-1809`: Latest version with the newest remoting with Windows Nano Server


### PR DESCRIPTION
Same as https://github.com/jenkinsci/docker/pull/975 and https://github.com/jenkinsci/docker-ssh-agent/pull/59 . Package difference concerns apply here as well