### PR TITLE
Fix SSH in the Windows Nanoserver images

### DIFF
--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -22,10 +22,16 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+FROM mcr.microsoft.com/windows/servercore:1809 AS core
+
 # If you pass in a POWERSHELL_VERSION, make sure it ends with a hyphen, leaving it empty will
 # use the 'latest'
 ARG POWERSHELL_VERSION=
 FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
+
+# The nanoserver image is nice and small, but we need a couple of things to get SSH working
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
+COPY --from=core /windows/system32/whoami.exe /windows/system32/whoami.exe
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/8/windows/nanoserver-1809/Dockerfile
+++ b/8/windows/nanoserver-1809/Dockerfile
@@ -22,10 +22,16 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+FROM mcr.microsoft.com/windows/servercore:1809 AS core
+
 # If you pass in a POWERSHELL_VERSION, make sure it ends with a hyphen, leaving it empty will
 # use the 'latest'
 ARG POWERSHELL_VERSION=
 FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
+
+# The nanoserver image is nice and small, but we need a couple of things to get SSH working
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
+COPY --from=core /windows/system32/whoami.exe /windows/system32/whoami.exe
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
As of right now, the nanoserver images produce the following error when trying to fetch an repository using ssh.

```
stderr:       0 [main] ssh (1552) C:\mingit\usr\bin\ssh.exe: *** fatal error - unable to load netapi32.dll, Win32 error 126
```

This pull requests adds the required files from the `servercore` image, to fix this issue.