### PR TITLE
Use JDK 8u272 on Alpine

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -23,7 +23,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u262-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 
 ARG VERSION=4.3
 ARG user=jenkins


### PR DESCRIPTION
## Use JDK 8u272 on Alpine

Latest JDK 8 release

See also https://github.com/jenkinsci/docker/pull/1008

See also https://github.com/jenkinsci/docker-ssh-agent/pull/67