### PR TITLE
[Hacktoberfest] Support JUnit format for Linux tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 bats-core/
+target/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,11 @@ pipeline {
                             }
                         }
                     }
+                    post {
+                        always {
+                            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What

Transform TAP output to JUnit using the https://www.npmjs.com/package/tap-xunit library within a docker container. 
NOTE: It does support windows for the time being.

### Why

Easy to visualise the test output in the build UI.

### How to test this

```
$ make build-alpine
$ make test-alpine
...

$ ls -1 target/
junit-results-alpine.xml
results-alpine.tap

$ head -3 target/junit-results-alpine.xml
<?xml version="1.0"?>
<testsuites>
  <testsuite tests="5" failures="0" errors="0" name="jenkinsci.docker-agent.alpine.Default">
```