### PR TITLE
Upgrade to Remoting 4.6.

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM adoptopenjdk/openjdk11:alpine
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/11/buster/Dockerfile
+++ b/11/buster/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM openjdk:11-jdk-buster
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/11/stretch/Dockerfile
+++ b/11/stretch/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM openjdk:11-jdk-stretch
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -54,7 +54,7 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk11-binaries/
     Write-Host 'Removing openjdk.zip ...'; `
     Remove-Item openjdk.zip -Force
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/11/windows/windowsservercore-1809/Dockerfile
+++ b/11/windows/windowsservercore-1809/Dockerfile
@@ -26,7 +26,7 @@ FROM adoptopenjdk:11-jdk-hotspot-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -25,7 +25,7 @@
 # Needs upgrade when/if there is an official alpine image.
 FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/8/buster/Dockerfile
+++ b/8/buster/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM openjdk:8-jdk-buster
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/8/stretch/Dockerfile
+++ b/8/stretch/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM openjdk:8-jdk-stretch
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/8/windows/nanoserver-1809/Dockerfile
+++ b/8/windows/nanoserver-1809/Dockerfile
@@ -54,7 +54,7 @@ RUN Write-Host ('Downloading https://github.com/AdoptOpenJDK/openjdk8-binaries/r
     Write-Host 'Removing openjdk.zip ...'; `
     Remove-Item openjdk.zip -Force
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/8/windows/windowsservercore-1809/Dockerfile
+++ b/8/windows/windowsservercore-1809/Dockerfile
@@ -26,7 +26,7 @@ FROM adoptopenjdk:8-jdk-hotspot-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=4.3
+ARG VERSION=4.6
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/make.ps1
+++ b/make.ps1
@@ -4,7 +4,7 @@ Param(
     [String] $Target = "build",
     [String] $AdditionalArgs = '',
     [String] $Build = '',
-    [String] $RemotingVersion = '4.3',
+    [String] $RemotingVersion = '4.6',
     [String] $BuildNumber = "6",
     [switch] $PushVersions = $false
 )

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -5,7 +5,7 @@ $AGENT_CONTAINER='pester-jenkins-jnlp-agent'
 $SHELL="powershell.exe"
 
 $FOLDER = Get-EnvOrDefault 'FOLDER' ''
-$VERSION = Get-EnvOrDefault 'VERSION' '4.3-1'
+$VERSION = Get-EnvOrDefault 'VERSION' '4.6-1'
 
 $REAL_FOLDER=Resolve-Path -Path "$PSScriptRoot/../${FOLDER}"
 


### PR DESCRIPTION
The 4.6 version of Remoting contains minor improvementx, mostly involving dependency updates.

See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.6) and the corresponding [core PR](https://github.com/jenkinsci/jenkins/pull/5043).

I think I caught all of the places that need to be updated.