### PR TITLE
Use Java 11 in default Docker images

### DIFF
--- a/11/buster/Dockerfile
+++ b/11/buster/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-debian
+FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-debian
 
 ARG VERSION=4.10
 ARG user=jenkins

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -23,7 +23,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u292-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u302-b08-alpine
 
 ARG VERSION=4.10
 ARG user=jenkins

--- a/8/buster/Dockerfile
+++ b/8/buster/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM adoptopenjdk/openjdk8:jdk8u292-b10-debian
+FROM adoptopenjdk/openjdk8:jdk8u302-b08-debian
 
 ARG VERSION=4.10
 ARG user=jenkins

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ docker run -i --rm --name agent1 --init -v agent1-workdir:C:/Users/jenkins/Work 
 The image has several supported configurations, which can be accessed via the following tags:
 
 * Linux Images:
-  * `latest` (`jdk8`, `buster-jdk8`, `latest-jdk8`, `latest-buster-jdk8`): Latest version with the newest remoting (based on `adoptopenjdk/openjdk8:jdk8u${version}-debian`)
-  * `latest-jdk11` (`jdk11`, `buster-jdk11`, `latest-buster-jdk11`): Latest version with the newest remoting and Java 11 (based on `adoptopenjdk/openjdk11:jdk-${version}-debian`)
-  * `alpine` (`alpine-jdk8`, `latest-alpine`, `latest-alpine-jdk8`): Small image based on Alpine Linux (based on `adoptopenjdk/openjdk8:jdk8u${version}-alpine`)
-  * `alpine-jdk11` (`latest-alpine-jdk11`): Small image based on Alpine Linux (based on `adoptopenjdk/openjdk11:alpine`)
+  * `latest` (`jdk11`, `buster-jdk11`, `latest-buster-jdk11`, `latest-jdk11`): Latest version with the newest remoting and Java 11 (based on `adoptopenjdk/openjdk11:jdk-${version}-debian`)
+  * `latest-jdk8` (`jdk8`, `buster-jdk8`, `latest-buster-jdk8`): Latest version with the newest remoting (based on `adoptopenjdk/openjdk8:jdk8u${version}-debian`)
+  * `alpine` (`alpine-jdk11`, `latest-alpine`, `latest-alpine-jdk11`): Small image based on Alpine Linux (based on `adoptopenjdk/openjdk11:alpine`)
+  * `alpine-jdk8` (`latest-alpine-jdk8`): Small image based on Alpine Linux (based on `adoptopenjdk/openjdk8:jdk8u${version}-alpine`)
   * `archlinux` (`latest-archlinux`, `archlinux-jdk11`, `latest-archlinux-jdk11`): Image based on Arch Linux with JDK11 (based on `archlinux:latest`)
 
 * Windows Images:

--- a/build.sh
+++ b/build.sh
@@ -77,8 +77,8 @@ if [[ "${target}" = "publish" ]] ; then
     export ON_TAG=true
     export BUILD_NUMBER=$build_number
   fi
-  docker buildx bake --push --file docker-bake.hcl \
-    linux
+  docker buildx bake --push --file docker-bake.hcl linux
+  exit_result=$?
 fi
 exit_if_error
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ disable_env_props=0
 exit_result=0
 
 function exit_if_error() {
-  if $exit_result
+  if [[ "$exit_result" != "0" ]]
   then
     echo "Build Failed!"
     exit $exit_result

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -108,10 +108,10 @@ target "debian_jdk8" {
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk8": "",
-    "${REGISTRY}/${JENKINS_REPO}:jdk8",
     "${REGISTRY}/${JENKINS_REPO}:buster-jdk8",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk8",
+    "${REGISTRY}/${JENKINS_REPO}:jdk8",
     "${REGISTRY}/${JENKINS_REPO}:latest-buster-jdk8",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk8",
   ]
   platforms = ["linux/amd64"]
 }
@@ -125,11 +125,11 @@ target "debian_jdk11" {
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}": "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk11": "",
-    "${REGISTRY}/${JENKINS_REPO}:jdk11",
     "${REGISTRY}/${JENKINS_REPO}:buster-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-buster-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
   ]
   platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -76,11 +76,8 @@ target "alpine_jdk8" {
     REMOTING_VERSION = REMOTING_VERSION
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine": "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk8": "",
-    "${REGISTRY}/${JENKINS_REPO}:alpine",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk8",
-    "${REGISTRY}/${JENKINS_REPO}:latest-alpine",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk8",
   ]
   platforms = ["linux/amd64"]
@@ -93,8 +90,11 @@ target "alpine_jdk11" {
     REMOTING_VERSION = REMOTING_VERSION
   }
   tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine": "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk11": "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine",
     "${REGISTRY}/${JENKINS_REPO}:alpine-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine",
     "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk11",
   ]
   platforms = ["linux/amd64"]
@@ -107,11 +107,9 @@ target "debian_jdk8" {
     REMOTING_VERSION = REMOTING_VERSION
   }
   tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}": "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk8": "",
     "${REGISTRY}/${JENKINS_REPO}:jdk8",
     "${REGISTRY}/${JENKINS_REPO}:buster-jdk8",
-    "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk8",
     "${REGISTRY}/${JENKINS_REPO}:latest-buster-jdk8",
   ]
@@ -125,9 +123,11 @@ target "debian_jdk11" {
     REMOTING_VERSION = REMOTING_VERSION
   }
   tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}": "",
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk11": "",
     "${REGISTRY}/${JENKINS_REPO}:jdk11",
     "${REGISTRY}/${JENKINS_REPO}:buster-jdk11",
+    "${REGISTRY}/${JENKINS_REPO}:latest",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-buster-jdk11",
   ]


### PR DESCRIPTION
## Use Java 11 in default Docker images

- Use Java 11 in default images
- Use AdoptOpenJDK 11.0.12 instead of 11.0.11
- Use AdoptOpenJDK 8u302 instead of 8u292
