### PR TITLE
Install missing font library in Debian images to prevent Java build failures

### DIFF
--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -47,7 +47,11 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN apt-get update && apt-get -y install git-lfs curl \
+RUN apt-get update \
+  && apt-get -y install \
+    git-lfs \
+    curl \
+    fontconfig \
   && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \

--- a/8/bullseye/Dockerfile
+++ b/8/bullseye/Dockerfile
@@ -36,7 +36,11 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN apt-get update && apt-get -y install git-lfs curl \
+RUN apt-get update \
+  && apt-get -y install \
+    git-lfs \
+    curl \
+    fontconfig \
   && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \


### PR DESCRIPTION
This is to prevent the issue described in jenkinsci/docker-agent#189

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Built both JDK 8 and 11 images locally where `apt list | grep libfreetype` shows:

```
root@d417078a191f:/home/jenkins# apt list | grep libfreetype
libfreetype6/now 2.10.4+dfsg-1 amd64 [installed,local]

```
