### PR TITLE
fix: enable long paths for git in Windows images

### DIFF
--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -92,6 +92,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -77,6 +77,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -92,6 +92,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -77,6 +77,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}

--- a/8/windows/nanoserver-1809/Dockerfile
+++ b/8/windows/nanoserver-1809/Dockerfile
@@ -93,6 +93,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -77,6 +77,8 @@ USER $user
 RUN New-Item -Type Directory $('{0}/.jenkins' -f $env:AGENT_ROOT) | Out-Null ; `
     New-Item -Type Directory $env:AGENT_WORKDIR | Out-Null
 
+RUN git config --global core.longpaths true
+
 VOLUME ${AGENT_ROOT}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR ${AGENT_ROOT}


### PR DESCRIPTION
As mentioned in https://github.com/jenkins-infra/helpdesk/issues/2847 there are issues in some plugin builds on Windows due to filenames length.

This PR sets the `core.longpaths` git setting to `true` globally for the user "Jenkins" in Windows images.
