### PR TITLE
Use MinGit 2.36.0 on Windows, not 2.35.3

### DIFF
--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=core $JAVA_HOME $JAVA_HOME
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerAdministrator
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -26,7 +26,7 @@ FROM eclipse-temurin:11.0.14.1_1-jdk-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=core $JAVA_HOME $JAVA_HOME
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerAdministrator
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -26,7 +26,7 @@ FROM eclipse-temurin:17.0.2_8-jdk-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/nanoserver-1809/Dockerfile
+++ b/8/windows/nanoserver-1809/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=core $JAVA_HOME $JAVA_HOME
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 USER ContainerAdministrator
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `

--- a/8/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/8/windows/windowsservercore-ltsc2019/Dockerfile
@@ -26,7 +26,7 @@ FROM eclipse-temurin:8u322-b06-jdk-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GIT_VERSION=2.35.3
+ARG GIT_VERSION=2.36.0
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `


### PR DESCRIPTION
## Use MinGit 2.36.0 on Windows, not 2.35.3

MinGit 2.36.0 includes fixes from 2.35.3 and more.

See https://github.com/git-for-windows/git/releases/tag/v2.36.0.windows.1

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
