### PR TITLE
feat(alpine) switch base image to official eclipse-temurin (alpine)

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -20,25 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG ALPINE_TAG=3.15.0
-FROM alpine:$ALPINE_TAG as jre-build
-
-RUN apk add --update --no-cache openjdk11-jdk openjdk11-jmods
-
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN jlink \
-         --module-path /usr/lib/jvm/default-jvm/jmods \
-         --add-modules ALL-MODULE-PATH \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
-
-ARG ALPINE_TAG=3.15.0
-FROM alpine:$ALPINE_TAG
+ARG JAVA_VERSION="11.0.14.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine
 
 ARG VERSION=4.13
 ARG user=jenkins
@@ -61,10 +44,6 @@ RUN apk add --update --no-cache curl bash git git-lfs musl-locales openssh-clien
   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
   && apk del --purge curl \
   && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
-
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -19,26 +19,8 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
-
-ARG ALPINE_TAG=3.15.0
-FROM alpine:$ALPINE_TAG as jre-build
-
-RUN apk add --update --no-cache openjdk17-jdk openjdk17-jmods
-
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN jlink \
-         --module-path /usr/lib/jvm/default-jvm/jmods \
-         --add-modules ALL-MODULE-PATH \
-         --strip-java-debug-attributes \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
-
-ARG ALPINE_TAG=3.15.0
-FROM alpine:$ALPINE_TAG
+ARG JAVA_VERSION="17.0.2_8"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine
 
 ARG VERSION=4.13
 ARG user=jenkins
@@ -61,10 +43,6 @@ RUN apk add --update --no-cache curl bash git git-lfs musl-locales openssh-clien
   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
   && apk del --purge curl \
   && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
-
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -20,8 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG ALPINE_TAG=3.15.0
-FROM alpine:$ALPINE_TAG
+ARG JAVA_VERSION="8u322-b06"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine
 
 ARG VERSION=4.13
 ARG user=jenkins
@@ -35,7 +35,7 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN apk add --update --no-cache curl bash git git-lfs musl-locales openjdk8-jre-base openssh-client openssl procps \
+RUN apk add --update --no-cache curl bash git git-lfs musl-locales openssh-client openssl procps \
   && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \


### PR DESCRIPTION
This PR switched the base image of the Alpine agents (JDK8, JDK11 and JDK17) from the stock "Alpine" to the official "eclipse-temurin" alpine variant.

It has the following benefits:

- Strict control of the JDK used, to control the version, as we were using the "latest" version as per the usual Alpine package manager style. "Latest" version is fine for some tools like `ca-certificates`, but in the case of the JDK, it is important to know which version is used or not.
- Faster and simplified builds for JDK11 and JDK17. We were using `jlink` to generate a custom JVM installation compliant with `musl` as no eclipse temurin Alpine image was available back then. It was convenient but being able to use the "stock" installation simplifies the Dockerfiles.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or Jira~
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
