### PR TITLE
Add `arm32` images to the build

### DIFF
--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -20,7 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:17.0.3_7-jdk-focal AS jre-build
+# To avoid "jmods: Value too large for defined data type" error,
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17.0.3_7-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -169,7 +169,7 @@ target "debian_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk11",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x"]
 }
 
 target "debian_jdk17" {
@@ -185,5 +185,5 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17-preview",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17-preview",
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,6 +17,13 @@ group "linux-arm64" {
   ]
 }
 
+group "linux-arm32" {
+  targets = [
+    "debian_jdk11",
+    "debian_jdk17",
+  ]
+}
+
 group "linux-s390x" {
   targets = [
     "debian_jdk11",


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

I added `linux/arm/v7` to `debian_jdk11` and `debian_jdk17` on the `docker-bake.hcl` file.
I also had to make a change in `17/bullseye/Dockerfile` because it wouldn't build by cause of a `jmods: Value too large for defined data type` error.

It now builds correctly for me when issuing: 

```bash
docker buildx bake -f docker-bake.hcl debian_jdk11
```
or 
```bash
docker buildx bake -f docker-bake.hcl debian_jdk17
```