### PR TITLE
Use Alpine 3.16 instead of Alpine 3.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The image has several supported configurations, which can be accessed via the fo
   * `archlinux` (`latest-archlinux`, `archlinux-jdk11`, `latest-archlinux-jdk11`): Image based on Arch Linux with JDK11 (based on `archlinux:latest`)
   * `bullseye-jdk17-preview` (`jdk17-preview`, `latest-bullseye-jdk17-preview`, `latest-jdk17-preview`): Preview JDK17 version with the newest remoting (based on `debian:bullseye-${builddate}`)
 
-From version 4.11.2, the alpine images are tagged using the alpine OS version as well (i.e. `alpine` ==> `alpine3.15`, `alpine-jdk8` ==> `alpine3.15-jdk8`).
+From version 4.11.2, the alpine images are tagged using the alpine OS version as well (i.e. `alpine` ==> `alpine3.16`, `alpine-jdk8` ==> `alpine3.16-jdk8`).
 
 * Windows Images:
   * `jdk8-windowsservercore-1809`: Latest version with the newest remoting and Java 8 (based on `eclipse-temurin:8.xxx-jdk-windowsservercore-1809`)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,7 +61,7 @@ variable "ON_TAG" {
 }
 
 variable "ALPINE_FULL_TAG" {
-  default = "3.15.4"
+  default = "3.16.1"
 }
 
 variable "ALPINE_SHORT_TAG" {


### PR DESCRIPTION
## Use Alpine 3.16 instead of Alpine 3.15

See Alpine 3.16 release notes at

* [Alpine 3.16.0 release notes](https://alpinelinux.org/posts/Alpine-3.16.0-released.html)
* [Alpine 3.16.1 release notes](https://alpinelinux.org/posts/Alpine-3.16.1-released.html)

Alpine 3.16.1 includes an openssl CVE fix and a busybox CVE fix.

* busybox [CVE-2022-30065](https://security.alpinelinux.org/vuln/CVE-2022-30065)
* openssl [CVE-2022-2097](https://security.alpinelinux.org/vuln/CVE-2022-2097)

The same fixes are available in Alpine 3.15.4 if we prefer to stay with Alpine 3.15.  I'm not aware of any compelling reason to remain with Alpine 3.15.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
