### PR TITLE
feature/Update referenced Alpine versions

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,7 +61,7 @@ variable "ON_TAG" {
 }
 
 variable "ALPINE_FULL_TAG" {
-  default = "3.16.1"
+  default = "3.16.2"
 }
 
 variable "ALPINE_SHORT_TAG" {


### PR DESCRIPTION
The upstream image for Alpine is now 3.16.2, rather than 3.16.1

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- N/A Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
The upstream versions for [jdk-11](https://github.com/adoptium/containers/blob/6ca246080b385f7d114f1c452264fe094d4d6203/11/jdk/alpine/Dockerfile.releases.full#L20), [jdk-8](https://github.com/adoptium/containers/blob/6ca246080b385f7d114f1c452264fe094d4d6203/8/jdk/alpine/Dockerfile.releases.full#L20), and [jdk-17](https://github.com/adoptium/containers/blob/6ca246080b385f7d114f1c452264fe094d4d6203/17/jdk/alpine/Dockerfile.releases.full#L20) all point to "alpine:3.16", which according to the [alpine official image page](https://hub.docker.com/_/alpine) is an alias of 3.16.2, rather than 3.16.1
- N/A Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
