### PR TITLE
Remove Java 8 dependency checking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,17 +26,6 @@ updates:
   labels:
   - dependencies
 
-- package-ecosystem: docker
-  directory: "8/alpine"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - dependencies
-
 # Arch Linux
 
 - package-ecosystem: docker
@@ -65,17 +54,6 @@ updates:
 
 - package-ecosystem: docker
   directory: "11/bullseye"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - dependencies
-
-- package-ecosystem: docker
-  directory: "8/bullseye"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -122,17 +100,6 @@ updates:
 
 - package-ecosystem: docker
   directory: "11/windows/windowsservercore-ltsc2019"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - slide
-  labels:
-  - dependencies
-
-- package-ecosystem: docker
-  directory: "8/windows/windowsservercore-ltsc2019"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2


### PR DESCRIPTION
## Remove Java 8 dependency checking

Java 8 was removed in earlier pull requests.  No value to checking dependencies on a Java version that is no longer supported.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
