### PR TITLE
 chore(pipeline) only deploy to DockerHub on tag-triggered builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,9 @@
 pipeline {
     agent none
 
-    options {        
+    options {
         buildDiscarder(logRotator(daysToKeepStr: '10'))
         timestamps()
-    }
-
-    triggers {
-        pollSCM('H * * * *')
     }
 
     stages {
@@ -23,39 +19,45 @@ pipeline {
                     environment {
                         DOCKERHUB_ORGANISATION = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
                     }
-                    steps {
-                        powershell '& ./build.ps1 test'
-                        script {
-                            def branchName = "${env.BRANCH_NAME}"
-                            if (branchName ==~ 'master') {
-                                // publish the images to Dockerhub
-                                infra.withDockerCredentials {
-                                    powershell '& ./build.ps1 publish'
-                                }
+                    stages('Build and Test') {
+                        // This stage is the "CI" and should be run on all code changes triggered by a code change
+                        when {
+                            not { buildingTag() }
+                        }
+                        steps {
+                            powershell '& ./build.ps1 test'
+                        }
+                        post {
+                            always {
+                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
                             }
-
-                            if(env.TAG_NAME != null) {
-                                def tagItems = env.TAG_NAME.split('-')
-                                if(tagItems.length == 2) {
-                                    def remotingVersion = tagItems[0]
-                                    def buildNumber = tagItems[1]
-                                    // we need to build and publish the tag version
-                                    infra.withDockerCredentials {
-                                        powershell "& ./build.ps1 -PushVersions -RemotingVersion $remotingVersion -BuildNumber $buildNumber -DisableEnvProps publish"
+                        }
+                    }
+                    stage('Deploy to DockerHub') {
+                        // This stage is the "CD" and should only be run when a tag triggered the build
+                        when {
+                            buildingTag()
+                        }
+                        steps {
+                            script {
+                                if(env.TAG_NAME != null) {
+                                    def tagItems = env.TAG_NAME.split('-')
+                                    if(tagItems.length == 2) {
+                                        def remotingVersion = tagItems[0]
+                                        def buildNumber = tagItems[1]
+                                        // This function is defined in the jenkins-infra/pipeline-library
+                                        infra.withDockerCredentials {
+                                            powershell "& ./build.ps1 -PushVersions -RemotingVersion $remotingVersion -BuildNumber $buildNumber -DisableEnvProps publish"
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                    post {
-                        always {
-                            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
-                        }
-                    }
                 }
                 stage('Linux') {
                     agent {
-                        label "docker&&linux"
+                        label "docker && linux"
                     }
                     options {
                         timeout(time: 30, unit: 'MINUTES')
@@ -63,57 +65,60 @@ pipeline {
                     environment {
                         DOCKERHUB_ORGANISATION = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
                     }
-                    steps {
-                        sh './build.sh'
-                        sh './build.sh test'
-                        script {
-                            def branchName = "${env.BRANCH_NAME}"
-                            if (branchName ==~ 'master') {
-                                // publish the images to Dockerhub
-                                infra.withDockerCredentials {
-                                    sh '''
-                                    docker buildx create --use
-                                    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                    ./build.sh publish
-                                    '''
-                                }
-                            } else if (env.TAG_NAME == null) {
-                                infra.withDockerCredentials {
-                                    sh '''
-                                        docker buildx create --use
-                                        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                        docker buildx bake --file docker-bake.hcl linux
-                                    '''
-                                }
+                    stages {
+                        stage('Prepare Docker') {
+                            steps {
+                                sh '''
+                                docker buildx create --use
+                                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                '''
                             }
-
-                            if(env.TAG_NAME != null) {
-                                def tagItems = env.TAG_NAME.split('-')
-                                if(tagItems.length == 2) {
-                                    def remotingVersion = tagItems[0]
-                                    def buildNumber = tagItems[1]
-                                    // we need to build and publish the tag version
-                                    infra.withDockerCredentials {
-                                        sh """
-                                        docker buildx create --use
-                                        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                        ./build.sh -r $remotingVersion -b $buildNumber -d publish
-                                        """
-                                    }
+                        }
+                        stage('Build and Test') {
+                            // This stage is the "CI" and should be run on all code changes triggered by a code change
+                            when {
+                                not { buildingTag() }
+                            }
+                            steps {
+                                sh './build.sh'
+                                sh './build.sh test'
+                                // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
+                                sh 'docker buildx bake --file docker-bake.hcl linux'
+                            }
+                            post {
+                                always {
+                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
                                 }
                             }
                         }
-                    }
-                    post {
-                        always {
-                            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                        stage('Deploy to DockerHub') {
+                            // This stage is the "CD" and should only be run when a tag triggered the build
+                            when {
+                                buildingTag()
+                            }
+                            steps {
+                                script {
+                                    def tagItems = env.TAG_NAME.split('-')
+                                    if(tagItems.length == 2) {
+                                        def remotingVersion = tagItems[0]
+                                        def buildNumber = tagItems[1]
+                                        // This function is defined in the jenkins-infra/pipeline-library
+                                        infra.withDockerCredentials {
+                                            sh """
+                                            docker buildx create --use
+                                            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                            ./build.sh -r ${remotingVersion} -b ${buildNumber} -d publish
+                                            """
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
         }
     }
-
 }
 
 // vim: ft=groovy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                     environment {
                         DOCKERHUB_ORGANISATION = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
                     }
-                    stages('Build and Test') {
+                    stage('Build and Test') {
                         // This stage is the "CI" and should be run on all code changes triggered by a code change
                         when {
                             not { buildingTag() }


### PR DESCRIPTION
This PR is the twin of https://github.com/jenkinsci/docker-inbound-agent/pull/280.

It ensures that only tag-based build are deploying to the Dockerhub to avoid overriding accidentally.
It also disables the pollSCM which was causing trouble on the remote system.


It's a first step forward fixing the JDK8 tags build with JDK11 issues.

