### PR TITLE
fix(aarch64) Format exec error on `aarch64` machines.

### DIFF
--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -21,7 +21,7 @@
 #  THE SOFTWARE.
 
 # To avoid "jmods: Value too large for defined data type" error,
-FROM --platform=$BUILDPLATFORM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility


### PR DESCRIPTION
Supposed to fix #308.

<!-- Please describe your pull request here. -->

I have just removed the `--platform=$BUILDPLATFORM` that causes the `bash: /opt/java/openjdk/bin/java: cannot execute binary file: Exec format error` on ` aarch64` machines.

Thanks a lot to @carpnick  for reporting this, researching the subject, and proposing a solution. 🙏 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
