### PR TITLE
Fix ARM64 Java in JDK17 Bullseye

### DIFF
--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -34,12 +34,12 @@ FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --strip-java-debug-attributes \
-  --no-man-pages \
-  --no-header-files \
-  --compress=2 \
-  --output /javaruntime
+         --add-modules ALL-MODULE-PATH \
+         --strip-java-debug-attributes \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
 
 FROM debian:bullseye-20221024 AS build
 
@@ -57,9 +57,9 @@ ARG AGENT_WORKDIR=/home/${user}/agent
 
 RUN apt-get update \
   && apt-get -y install \
-  git-lfs \
-  curl \
-  fontconfig \
+    git-lfs \
+    curl \
+    fontconfig \
   && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -41,7 +41,6 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-
 FROM debian:bullseye-20221024 as build
 
 ARG VERSION=3071.v7e9b_0dc08466

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -34,12 +34,12 @@ FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --strip-java-debug-attributes \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
+  --add-modules ALL-MODULE-PATH \
+  --strip-java-debug-attributes \
+  --no-man-pages \
+  --no-header-files \
+  --compress=2 \
+  --output /javaruntime
 
 FROM debian:bullseye-20221024 AS build
 
@@ -57,9 +57,9 @@ ARG AGENT_WORKDIR=/home/${user}/agent
 
 RUN apt-get update \
   && apt-get -y install \
-    git-lfs \
-    curl \
-    fontconfig \
+  git-lfs \
+  curl \
+  fontconfig \
   && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \
@@ -80,17 +80,17 @@ VOLUME /home/${user}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR /home/${user}
 
+LABEL \
+  org.opencontainers.image.vendor="Jenkins project" \
+  org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \
+  org.opencontainers.image.description="This is a base image, which provides the Jenkins agent executable (agent.jar)" \
+  org.opencontainers.image.version="${VERSION}" \
+  org.opencontainers.image.url="https://www.jenkins.io/" \
+  org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
+  org.opencontainers.image.licenses="MIT"
+
 FROM build AS default
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 FROM build AS arm32
 COPY --from=arm32-jre-build /javaruntime $JAVA_HOME
-
-LABEL \
-    org.opencontainers.image.vendor="Jenkins project" \
-    org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \
-    org.opencontainers.image.description="This is a base image, which provides the Jenkins agent executable (agent.jar)" \
-    org.opencontainers.image.version="${VERSION}" \
-    org.opencontainers.image.url="https://www.jenkins.io/" \
-    org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
-    org.opencontainers.image.licenses="MIT"

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -22,11 +22,11 @@
 
 # To avoid "jmods: Value too large for defined data type" error,
 # Check docker bake target debian_jdk17_arm32
-# Cannot get jlink to properly work, in the v7 environment.  The jmods error
-# above gets generated each time.  Better to have a larger image than 
-# incorrect java binaries in 32bit arm.
-FROM  eclipse-temurin:17.0.4.1_1-jdk-focal AS arm32-jre-build
-RUN cp -r /opt/java/openjdk  /javaruntime
+# Cannot get jlink to properly work, in the v7 environment.
+# The jmods error above gets generated each time.
+# Better to have a larger image than incorrect java binaries in 32bit arm.
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS arm32-jre-build
+RUN cp -r /opt/java/openjdk /javaruntime
 
 FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
 

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -80,7 +80,7 @@ VOLUME /home/${user}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR /home/${user}
 
-FROM build as default
+FROM build AS default
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 FROM build as arm32

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -83,7 +83,7 @@ WORKDIR /home/${user}
 FROM build AS default
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-FROM build as arm32
+FROM build AS arm32
 COPY --from=arm32-jre-build /javaruntime $JAVA_HOME
 
 LABEL \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -80,13 +80,11 @@ VOLUME /home/${user}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR /home/${user}
 
-
 FROM build as default
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 FROM build as arm32
 COPY --from=arm32-jre-build /javaruntime $JAVA_HOME
-
 
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -41,7 +41,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20221024 as build
+FROM debian:bullseye-20221024 AS build
 
 ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -21,7 +21,14 @@
 #  THE SOFTWARE.
 
 # To avoid "jmods: Value too large for defined data type" error,
-FROM --platform=$BUILDPLATFORM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
+# Check docker bake target debian_jdk17_arm32
+# Cannot get jlink to properly work, in the v7 environment.  The jmods error
+# above gets generated each time.  Better to have a larger image than 
+# incorrect java binaries in 32bit arm.
+FROM  eclipse-temurin:17.0.4.1_1-jdk-focal AS arm32-jre-build
+RUN cp -r /opt/java/openjdk  /javaruntime
+
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
@@ -34,7 +41,8 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20221024
+
+FROM debian:bullseye-20221024 as build
 
 ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins
@@ -64,7 +72,6 @@ ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
@@ -73,6 +80,14 @@ RUN mkdir /home/${user}/.jenkins && mkdir -p ${AGENT_WORKDIR}
 VOLUME /home/${user}/.jenkins
 VOLUME ${AGENT_WORKDIR}
 WORKDIR /home/${user}
+
+
+FROM build as default
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+FROM build as arm32
+COPY --from=arm32-jre-build /javaruntime $JAVA_HOME
+
 
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -140,8 +140,6 @@ target "debian_jdk11" {
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x"]
 }
 
-
-
 target "debian_jdk17" {
   dockerfile = "17/bullseye/Dockerfile"
   context = "."

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -145,8 +145,9 @@ target "debian_jdk17" {
   context = "."
   args = {
     VERSION = REMOTING_VERSION,
-    target = "default"
+    
   }
+  target = "default"
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
     "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk17",
@@ -162,8 +163,9 @@ target "debian_jdk17_arm32" {
   context = "."
   args = {
     VERSION = REMOTING_VERSION,
-    target = "arm32"
+    
   }
+  target = "arm32"
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
     "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk17",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,7 @@ group "linux" {
     "archlinux_jdk11",
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk17_arm32"
   ]
 }
 
@@ -18,7 +19,7 @@ group "linux-arm64" {
 group "linux-arm32" {
   targets = [
     "debian_jdk11",
-    "debian_jdk17",
+    "debian_jdk17_arm32"
   ]
 }
 
@@ -139,11 +140,14 @@ target "debian_jdk11" {
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x"]
 }
 
+
+
 target "debian_jdk17" {
   dockerfile = "17/bullseye/Dockerfile"
   context = "."
   args = {
-    VERSION = REMOTING_VERSION
+    VERSION = REMOTING_VERSION,
+    target = "default"
   }
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
@@ -152,5 +156,22 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "debian_jdk17_arm32" {
+  dockerfile = "17/bullseye/Dockerfile"
+  context = "."
+  args = {
+    VERSION = REMOTING_VERSION,
+    target = "arm32"
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
+    "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
+  ]
+  platforms = ["linux/arm/v7"]
 }


### PR DESCRIPTION
Fixes #308.  Use platform dependent image by default to get correct java runtime.

Use native java runtime when on arm32 to get around jmods error:
"jmods: Value too large for defined data type" error

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~Link to relevant pull requests, esp. upstream and downstream changes~
- ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
