### PR TITLE
chore: ensure that JAVA_VERSION is always specified through a Docker build argument

### DIFF
--- a/11/archlinux/Dockerfile
+++ b/11/archlinux/Dockerfile
@@ -20,14 +20,13 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM archlinux:latest AS jre-build
-
-RUN pacman -Syu jdk11-openjdk --noconfirm
+ARG JAVA_VERSION="11.0.16.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN /usr/lib/jvm/default-runtime/bin/jlink \
+RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \
          --no-man-pages \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -20,7 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:11.0.16.1_1-jdk-focal AS jre-build
+ARG JAVA_VERSION="11.0.16.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -22,7 +22,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:11.0.16.1_1-jdk-windowsservercore-1809
+ARG JAVA_VERSION="11.0.16.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -25,10 +25,12 @@
 # Cannot get jlink to properly work, in the v7 environment.
 # The jmods error above gets generated each time.
 # Better to have a larger image than incorrect java binaries in 32bit arm.
-FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS arm32-jre-build
+ARG JAVA_VERSION="17.0.4.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-focal AS arm32-jre-build
 RUN cp -r /opt/java/openjdk /javaruntime
 
-FROM eclipse-temurin:17.0.4.1_1-jdk-focal AS jre-build
+ARG JAVA_VERSION="17.0.4.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-focal AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -22,7 +22,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM eclipse-temurin:17.0.4.1_1-jdk-windowsservercore-1809
+ARG JAVA_VERSION="17.0.4.1_1"
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
In order to ensure that we can track the JDK versions with any tool such as Updatecli (or renovabot), this PR ensures that the JDK version is always specified on the same way to Dockerfiles by using a build argument `JAVA_VERSION`.

Please note that:

- Archlinux is now using the same JDK (fixed) version as Debian (e.g. Eclipse Temurin built from the official image).
- There is no "centralized" version to avoid repetition (like it is currently for the remoting version).

----

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[] Link to relevant issues in GitHub or Jira~
- ~[] Link to relevant pull requests, esp. upstream and downstream changes~
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~
