### PR TITLE
chore: track JDK versions (11 and 17) with updatecli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,3 +108,15 @@ updates:
   - slide
   labels:
   - dependencies
+
+# GitHub actions
+
+- package-ecosystem: "github-actions"
+  target-branch: master
+  directory: "/"
+  schedule:
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"
+  labels:
+  - chore
+  - github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,6 +117,3 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
-  labels:
-  - chore
-  - github-actions

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,28 @@
+name: updatecli
+on:
+  # Allow to be run manually
+  workflow_dispatch:
+  schedule:
+    # Run once per week (to avoid alert fatigue)
+    - cron: '0 2 * * 1' # Every Monday at 2am UTC
+  push:
+  pull_request:
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2.13.0
+
+      - name: Run Updatecli in Dry Run mode
+        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Updatecli in Apply mode
+        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,6 +23,7 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Updatecli in Apply mode
+        if: github.ref == 'refs/heads/master'
         run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -1,0 +1,141 @@
+---
+name: Bump JDK11 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK11 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin11-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
+        # jdk-11.0.16.1+1 (https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.16.1%2B1) is OK
+        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+      - replacer:
+          from: +
+          to: _
+
+conditions:
+  checkTemurinAlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-alpine'
+  checkTemurinDebianDockerImageAmd64:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImageArm64:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: arm64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImages390x:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: s390x
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImagesArmv7:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: arm/v7
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinWindowsCoreDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
+
+targets:
+  setJDK11VersionAlpine:
+    name: "Bump JDK11 version on Alpine image"
+    kind: dockerfile
+    spec:
+      file: 11/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionDebian:
+    name: "Bump JDK11 version on Debian image"
+    kind: dockerfile
+    spec:
+      file: 11/bullseye/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionArch:
+    name: "Bump JDK11 version on Archlinux image"
+    kind: dockerfile
+    spec:
+      file: 11/archlinux/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionWindowsNanoserver1809:
+    name: "Bump JDK11 version on Windows Nanoserver 1809 image"
+    kind: dockerfile
+    spec:
+      file: 11/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK11VersionWindowsServerLtsc2019:
+    name: "Bump JDK11 version on Windows Server LTSC 2019 image"
+    kind: dockerfile
+    spec:
+      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump JDK11 version to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk11

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -1,0 +1,132 @@
+---
+name: Bump JDK17 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK17 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin17-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
+        # jdk-17.0.4.1+1(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.4.1%2B1) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)(.(\\d*))+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+      - replacer:
+          from: +
+          to: _
+
+conditions:
+  checkTemurinAlpineDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-alpine'
+  checkTemurinDebianDockerImageAmd64:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImageArm64:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: arm64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImages390x:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: s390x
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinDebianDockerImagesArmv7:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
+    disablesourceinput: true
+    spec:
+      architecture: arm/v7
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-focal'
+  checkTemurinWindowsCoreDockerImage:
+    kind: dockerimage
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    disablesourceinput: true
+    spec:
+      architecture: amd64
+      image: eclipse-temurin
+      tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
+
+targets:
+  setJDK17VersionAlpine:
+    name: "Bump JDK17 version on Alpine image"
+    kind: dockerfile
+    spec:
+      file: 17/alpine/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK17VersionDebian:
+    name: "Bump JDK17 version on Debian image"
+    kind: dockerfile
+    spec:
+      file: 17/bullseye/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK17VersionWindowsNanoserver1809:
+    name: "Bump JDK17 version on Windows Nanoserver 1809 image"
+    kind: dockerfile
+    spec:
+      file: 17/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+  setJDK17VersionWindowsServerLtsc2019:
+    name: "Bump JDK17 version on Windows Server LTSC 2019 image"
+    kind: dockerfile
+    spec:
+      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump JDK17 version to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk17

--- a/updatecli/values.github-action.yaml
+++ b/updatecli/values.github-action.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "GitHub Actions"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "github-actions"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "master"
+  owner: "jenkinsci"
+  repository: "docker-agent"


### PR DESCRIPTION
This PR introduces automatic version tracking of JDK11 and JDK17 (for now) using updatecli.

Merging this PR would trigger a new JDK11 update PR at least (JDK17 17.0.5 is not available as Docker image yet for Eclipse Temurin).

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
