### PR TITLE
chore(linux tests) remove deprecated jdk17-only check

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -75,7 +75,7 @@ ARCH=${ARCH:-x86_64}
 @test "[${SUT_IMAGE}] use build args correctly" {
   cd "${BATS_TEST_DIRNAME}"/.. || false
 
-  local TEST_VERSION="3.36"
+  local TEST_VERSION="3025.vf64a_a_3da_6b_55" # Older version, must work with JDK11 and JDK17 and should contain https://github.com/jenkinsci/remoting/pull/532
   local TEST_USER="test-user"
   local TEST_GROUP="test-group"
   local TEST_UID=2000
@@ -102,12 +102,8 @@ docker buildx bake \
 
   is_agent_container_running "${cid}"
 
-  # TODO https://github.com/jenkinsci/remoting/pull/481
-  # Current line is: 'A terminally deprecated method in java.lang.System has been called'
-  if [[ $IMAGE != *"17"* ]]; then
-    run docker exec "${cid}" sh -c "java -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -version"
-    assert_line --index 0 "${TEST_VERSION}"
-  fi
+  run docker exec "${cid}" sh -c "java -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -version"
+  assert_line --index 0 "${TEST_VERSION}"
 
   run docker exec "${cid}" sh -c "id -u -n ${TEST_USER}"
   assert_line --index 0 "${TEST_USER}"


### PR DESCRIPTION
Fix https://github.com/jenkinsci/docker-agent/issues/304

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
