### PR TITLE
feat(linux) add curl

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -23,7 +23,6 @@
 ARG JAVA_VERSION=11.0.17_8
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine
 
-ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -32,21 +31,19 @@ ARG gid=1000
 RUN addgroup -g "${gid}" "${group}" \
   && adduser -h /home/"${user}" -u "${uid}" -G "${group}" -D "${user}"
 
-ARG AGENT_WORKDIR=/home/"${user}"/agent
-
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 ## Always use the latest Alpine packages: no need for versions
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl bash git git-lfs musl-locales openssh-client openssl procps \
-  && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/agent.jar \
-  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
-  && apk del --purge curl \
   && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
+ARG VERSION=3071.v7e9b_0dc08466
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+
 USER "${user}"
+ARG AGENT_WORKDIR=/home/"${user}"/agent
 ENV AGENT_WORKDIR="${AGENT_WORKDIR}"
 RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 

--- a/11/archlinux/Dockerfile
+++ b/11/archlinux/Dockerfile
@@ -36,7 +36,6 @@ RUN jlink \
 
 FROM archlinux:base-20221106.0.100148
 
-ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -47,12 +46,11 @@ RUN groupadd -g "${gid}" "${group}" \
 
 ARG AGENT_WORKDIR=/home/"${user}"/agent
 
-RUN pacman -Syu git git-lfs --noconfirm
+RUN pacman -Syu curl git git-lfs --noconfirm
 
-RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/agent.jar \
-  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+ARG VERSION=3071.v7e9b_0dc08466
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -36,7 +36,6 @@ RUN jlink \
 
 FROM debian:bullseye-20221024
 
-ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -55,12 +54,11 @@ RUN apt-get update \
     curl \
     ca-certificates \
     fontconfig \
-  && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/agent.jar \
-  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
-  && apt-get remove -y curl \
   && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION=3071.v7e9b_0dc08466
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV LANG C.UTF-8
 

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -22,7 +22,6 @@
 ARG JAVA_VERSION=17.0.5_8
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine
 
-ARG VERSION=3071.v7e9b_0dc08466
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -38,12 +37,11 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ## Always use the latest Alpine packages: no need for versions
 # hadolint ignore=DL3018
 RUN apk add --no-cache curl bash git git-lfs musl-locales openssh-client openssl procps \
-  && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/agent.jar \
-  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
-  && apk del --purge curl \
   && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+
+ARG VERSION=3071.v7e9b_0dc08466
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 USER "${user}"
 ENV AGENT_WORKDIR="${AGENT_WORKDIR}"

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -64,12 +64,11 @@ RUN apt-get update \
     curl \
     ca-certificates \
     fontconfig \
-  && curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/agent.jar \
-  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar \
-  && apt-get remove -y curl \
   && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION=3071.v7e9b_0dc08466
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV LANG C.UTF-8
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -32,7 +32,7 @@ ARCH=${ARCH:-x86_64}
   assert_equal "${output}" "UTF-8"
 }
 
-@test "[${SUT_IMAGE}] image has bash and java installed and in the PATH" {
+@test "[${SUT_IMAGE}] image has bash, curl and java installed and in the PATH" {
   local cid
   cid="$(docker run -d -it -P "${SUT_IMAGE}" /bin/bash)"
 
@@ -42,6 +42,12 @@ ARCH=${ARCH:-x86_64}
   assert_success
   run docker exec "${cid}" bash --version
   assert_success
+
+  run docker exec "${cid}" sh -c "command -v curl"
+  assert_success
+  run docker exec "${cid}" sh -c "curl --version"
+  assert_success
+
   run docker exec "${cid}" sh -c "command -v java"
   assert_success
 


### PR DESCRIPTION
This PR fixes #153 but is blocked by #320 .

It adds `curl` on all the Linux images + the root CA certificates (to ensure any HTTPS website can be used with `curl`).

It also stop using `curl` to download the remoting: the `Dockerfile` directive `ADD` is used instead to benefit from BuildX optimization, benefit from improved caching and simplify instructions (less layers, less code and faster builds).
Please note that the `ADD` instruction will soon support checksum https://docs.docker.com/engine/reference/builder/#verifying-a-remote-file-checksum-add---checksumchecksum-http-src-dest.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
