### PR TITLE
fix(debian_jdk17) revert #310 and use `TARGETPLATFORM` to detect if arm/v7 or not

### DIFF
--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -20,28 +20,28 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-# To avoid "jmods: Value too large for defined data type" error,
-# Check docker bake target debian_jdk17_arm32
-# Cannot get jlink to properly work, in the v7 environment.
-# The jmods error above gets generated each time.
-# Better to have a larger image than incorrect java binaries in 32bit arm.
-ARG JAVA_VERSION=17.0.5_8
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal AS arm32-jre-build
-RUN cp -r /opt/java/openjdk /javaruntime
-
 ARG JAVA_VERSION=17.0.5_8
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal AS jre-build
+
+# This Build ARG is populated by Docker
+# Ref. https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETPLATFORM
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN jlink \
+RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
+  jlink \
     --add-modules ALL-MODULE-PATH \
     --strip-java-debug-attributes \
     --no-man-pages \
     --no-header-files \
     --compress=2 \
-    --output /javaruntime
+    --output /javaruntime; \
+  # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
+  # Because jlink fails with the error "jmods: Value too large for defined data type" error.
+  else cp -r /opt/java/openjdk /javaruntime; \
+  fi
 
 FROM debian:bullseye-20221024 AS build
 
@@ -73,6 +73,7 @@ RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=jre-build /javaruntime "$JAVA_HOME"
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 
 USER "${user}"
@@ -91,9 +92,3 @@ LABEL \
   org.opencontainers.image.url="https://www.jenkins.io/" \
   org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
   org.opencontainers.image.licenses="MIT"
-
-FROM build AS default
-COPY --from=jre-build /javaruntime "$JAVA_HOME"
-
-FROM build AS arm32
-COPY --from=arm32-jre-build /javaruntime "$JAVA_HOME"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2015-2020 Jenkins project contributors
+Copyright (c) 2015-2022 Jenkins project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,7 +5,6 @@ group "linux" {
     "archlinux_jdk11",
     "debian_jdk11",
     "debian_jdk17",
-    "debian_jdk17_arm32"
   ]
 }
 
@@ -19,7 +18,7 @@ group "linux-arm64" {
 group "linux-arm32" {
   targets = [
     "debian_jdk11",
-    "debian_jdk17_arm32"
+    "debian_jdk17"
   ]
 }
 
@@ -145,9 +144,7 @@ target "debian_jdk17" {
   context = "."
   args = {
     VERSION = REMOTING_VERSION,
-    
   }
-  target = "default"
   tags = [
     equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
     "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk17",
@@ -155,23 +152,5 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
-}
-
-target "debian_jdk17_arm32" {
-  dockerfile = "17/bullseye/Dockerfile"
-  context = "."
-  args = {
-    VERSION = REMOTING_VERSION,
-    
-  }
-  target = "arm32"
-  tags = [
-    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk17": "",
-    "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk17",
-    "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
-  ]
-  platforms = ["linux/arm/v7"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 }


### PR DESCRIPTION
Related to https://github.com/jenkinsci/docker-agent/issues/323 and https://github.com/jenkinsci/docker-agent/issues/308.

This PR reverts #310 and fixes #308 with a similar approach but with the "conditionnality" of the `arm/v7` directly inside the `Dockerfile` 's `jre-build` stage.

While reading https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/, I confirmed @carpnick 's analysis about the `BUILDPLATFORM`. But it seems that Docker provides another variable which is `TARGETPLATFORM` which is populated with the value we expect.

https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope shows the documentation reference with an exemple on "how to" use this variable as a build argument: is is what this PR does.

Tested locally with a local registry and a "smoke test":

```console
# Start a local registry to test the `--push` option
$ docker run -d -p 5000:5000 --restart=always --name registry registry:2

# A buildx runner is required to test multi-arch, but it's allowed to reach the `localhost:5000` of the Docker Engine which points to the registry through the Docker port forwarding
$ docker buildx create --use --driver-opt network=host 

# Build and push to the local registry
$ REGISTRY=localhost:5000 JENKINS_REPO=agent docker buildx bake --file docker-bake.hcl --push debian_jdk17

# Smoke tests
for arch in 'linux/amd64' 'linux/arm64' 'linux/arm/v7'; do echo "==$arch=="; docker run --platform="$arch" --rm --entrypoint='' localhost:5000/agent:jdk17 sh -c 'uname -m && java -version';done
==linux/amd64==
Unable to find image 'localhost:5000/agent:jdk17' locally
jdk17: Pulling from agent
Digest: sha256:385f9ebe6a724ac32447eaab2c945fef3d0db1bad558a50b7ae39c765b33a7e9
Status: Downloaded newer image for localhost:5000/agent:jdk17
x86_64
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment Temurin-17.0.5+8 (build 17.0.5+8)
OpenJDK 64-Bit Server VM Temurin-17.0.5+8 (build 17.0.5+8, mixed mode)
==linux/arm64==
Unable to find image 'localhost:5000/agent:jdk17' locally
jdk17: Pulling from agent
Digest: sha256:385f9ebe6a724ac32447eaab2c945fef3d0db1bad558a50b7ae39c765b33a7e9
Status: Downloaded newer image for localhost:5000/agent:jdk17
aarch64
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment Temurin-17.0.5+8 (build 17.0.5+8)
OpenJDK 64-Bit Server VM Temurin-17.0.5+8 (build 17.0.5+8, mixed mode)
==linux/arm/v7==
Unable to find image 'localhost:5000/agent:jdk17' locally
jdk17: Pulling from agent
Digest: sha256:385f9ebe6a724ac32447eaab2c945fef3d0db1bad558a50b7ae39c765b33a7e9
Status: Downloaded newer image for localhost:5000/agent:jdk17
armv7l
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment Temurin-17.0.5+8 (build 17.0.5+8)
OpenJDK Server VM Temurin-17.0.5+8 (build 17.0.5+8, mixed mode, sharing)
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
