### PR TITLE
chore(updatecli) adapt manifest for v0.38.0

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.14.0
+        uses: updatecli/updatecli-action@v2.15.0
 
       - name: Run Updatecli in Dry Run mode
         run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -42,36 +42,16 @@ conditions:
       architecture: amd64
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-alpine'
-  checkTemurinDebianDockerImageAmd64:
+  checkTemurinDebianDockerImages:
     kind: dockerimage
     name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
     disablesourceinput: true
     spec:
-      architecture: amd64
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImageArm64:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: arm64
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImages390x:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: s390x
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImagesArmv7:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: arm/v7
+      architectures:
+        - amd64
+        - arm64
+        - s390x
+        - arm/v7
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-focal'
   checkTemurinWindowsCoreDockerImage:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -42,36 +42,16 @@ conditions:
       architecture: amd64
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-alpine'
-  checkTemurinDebianDockerImageAmd64:
+  checkTemurinDebianDockerImages:
     kind: dockerimage
     name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
     disablesourceinput: true
     spec:
-      architecture: amd64
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImageArm64:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: arm64
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImages390x:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: s390x
-      image: eclipse-temurin
-      tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinDebianDockerImagesArmv7:
-    kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available
-    disablesourceinput: true
-    spec:
-      architecture: arm/v7
+      architectures:
+        - amd64
+        - arm64
+        - s390x
+        - arm/v7
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-focal'
   checkTemurinWindowsCoreDockerImage:


### PR DESCRIPTION
- Bumps the GitHub actions for update to latest `2.15.0` which features the 0.38.0 version of updatecli
- Simplify the conditions

