### PR TITLE
fix(linux) ensure that users different than jenkins and root are allowed to start agent process

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -40,7 +40,8 @@ RUN apk add --no-cache curl bash git git-lfs musl-locales openssh-client openssl
 
 ARG VERSION=3077.vd69cf116da_6f
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
-RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 USER "${user}"
 ARG AGENT_WORKDIR=/home/"${user}"/agent

--- a/11/archlinux/Dockerfile
+++ b/11/archlinux/Dockerfile
@@ -50,7 +50,8 @@ RUN pacman -Syu curl git git-lfs openssh --noconfirm
 
 ARG VERSION=3077.vd69cf116da_6f
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
-RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -50,20 +50,21 @@ ARG AGENT_WORKDIR=/home/${user}/agent
 # hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get --yes --no-install-recommends install \
-     ca-certificates \
-     curl \
-     fontconfig \
-     git \
-     git-lfs \
-     less \
-     netbase \
-     openssh-client \
-     patch \
+    ca-certificates \
+    curl \
+    fontconfig \
+    git \
+    git-lfs \
+    less \
+    netbase \
+    openssh-client \
+    patch \
   && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION=3077.vd69cf116da_6f
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
-RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV LANG C.UTF-8
 

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -41,7 +41,8 @@ RUN apk add --no-cache curl bash git git-lfs musl-locales openssh-client openssl
 
 ARG VERSION=3077.vd69cf116da_6f
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
-RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 USER "${user}"
 ENV AGENT_WORKDIR="${AGENT_WORKDIR}"

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -73,7 +73,8 @@ RUN apt-get update \
 
 ARG VERSION=3077.vd69cf116da_6f
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
-RUN ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
 ENV LANG C.UTF-8
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -83,6 +83,11 @@ ARCH=${ARCH:-x86_64}
   cleanup "$cid"
 }
 
+@test "[${SUT_IMAGE}] Another user 'root' or 'jenkins' is able to start an agent process" {
+  run docker run --rm --user=2222:2222 --entrypoint='' "${SUT_IMAGE}" java -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -version
+  assert_success
+}
+
 @test "[${SUT_IMAGE}] use build args correctly" {
   cd "${BATS_TEST_DIRNAME}"/.. || false
 


### PR DESCRIPTION
Related to https://github.com/jenkinsci/docker-inbound-agent/issues/307, this PR ensures that any user, other than the default `jenkins`, root, and not included in the `jenkins` group (GID `1000`) can read the `agent.jar` file.

A test has been added, which underlines the issue.

Fixup of https://github.com/jenkinsci/docker-agent/pull/321.

Thanks to @peterwvj and their colleague for pointing out the problem.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
