### PR TITLE
chore(updatecli) tracks bats version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,7 @@ list: check-reqs
 	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'
 
 bats:
-	git clone https://github.com/bats-core/bats-core bats ;\
-	cd bats ;\
-	git checkout v1.4.1
+	git clone --branch v1.4.1 https://github.com/bats-core/bats-core ./bats
 
 prepare-test: bats check-reqs
 	git submodule update --init --recursive

--- a/updatecli/updatecli.d/bats.yaml
+++ b/updatecli/updatecli.d/bats.yaml
@@ -1,0 +1,49 @@
+---
+name: Bump bats version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest bats version
+    spec:
+      owner: bats-core
+      repository: bats-core
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+targets:
+  setBatsVersionInMakefile:
+    kind: file
+    name: Update Makefile
+    spec:
+      file: Makefile
+      matchpattern: >
+        git clone --branch (.*) https://github.com/bats-core/bats-core ./bats
+      replacepattern: >
+        git clone --branch {{ source "lastVersion" }} https://github.com/bats-core/bats-core ./bats
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump bats version to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - tests
+        - bats


### PR DESCRIPTION
This PR ensures that updatecli tracks the version of bats, the shell framework used for testing the Linux images.

Please note that:
- This PR has no functionnal change
- The updatecli checks will fail because it searches for the pattern on the `master` branch, but the pattern is changed as part of the PR. It means that I'll have to check for updatecli "success" once merged. If I force updatecli to ignore SCM locally, the expected result is the following:

```console
TARGETS
========

setBatsVersionInMakefile
------------------------

**Dry Run enabled**

⚠ updated the [dry run] content of the file "Makefile"

--- Makefile
+++ Makefile
@@ -52,7 +52,7 @@
        @set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'
 
 bats:
-       git clone --branch v1.4.1 https://github.com/bats-core/bats-core ./bats
+       git clone --branch v1.8.2 https://github.com/bats-core/bats-core ./bats
 
 prepare-test: bats check-reqs
        git submodule update --init --recursive
```