### PR TITLE
feat(documentation) Adds a small paragraph describing how to use another timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Sat Nov 26 01:27:58 CST 2022
 
 ### Using the `jenkins/agent` image as a base image
 
-Should you want to adapt it to your local timezone while creating your own image based on `jenkins/agent`, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
+Should you want to adapt the `jenkins/agent` image to your local timezone while creating your own image based on it, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
 
 ```dockerfile
 FROM jenkins/agent as agent

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ FROM jenkins/agent as agent
  [...]
 ENV TIME_ZONE=Asia/Shanghai
  [...]
-RUN ln -snf /usr/share/zoneinfo/$TIME_ZONE /etc/localtime && echo $TIME_ZONE > /etc/timezone \
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
     && dpkg-reconfigure -f noninteractive tzdata \
  [...] 
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,28 @@ See the full list [here](https://hub.docker.com/r/jenkins/agent/tags)
 
 ## Timezones
 
+### Using directly the `jenkins/agent` image
+
 By default, the image is using the `Etc/UTC` timezone.
+If you want to use your timezone of your machine, you can mount the `/etc/localtime` file from the host (as per [this comment](https://github.com/moby/moby/issues/12084#issuecomment-89697533)).
+In this example, the machine is using the `Europe/Paris` timezone.
+
+```bash
+$ docker run --rm -ti --entrypoint=date -v /etc/localtime:/etc/localtime:ro jenkins/agent
+Fri Nov 25 18:27:22 CET 2022
+```
+
+You can also set the `TZ` environment variable to the desired timezone.
+`TZ` is a standard POSIX environment variable used by many images, see [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for a list of valid values.
+The next command is run on a machine using the `Europe/Paris` timezone a few seconds after the previous one.
+
+```bash
+$ docker run --rm -ti --env TZ=Asia/Shanghai --entrypoint=date jenkins/agent
+Sat Nov 26 01:27:58 CST 2022 
+```
+
+### Using the `jenkins/agent` image as a base image
+
 Should you want to adapt it to your local timezone while creating your own image based on `jenkins/agent`, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
 
 ```dockerfile

--- a/README.md
+++ b/README.md
@@ -79,3 +79,17 @@ The file `docker-bake.hcl` defines all the configuration for Linux images and th
 
 There are also versioned tags in DockerHub, and they are recommended for production use.
 See the full list [here](https://hub.docker.com/r/jenkins/agent/tags)
+
+## Timezones
+
+By default, the image is using the `Etc/UTC` timezone. Should you want to adapt it to your local timezone while creating your own image based on `jenkins/agent`, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
+
+```dockerfile
+FROM jenkins/agent as agent
+ [...]
+ENV TIME_ZONE=Asia/Shanghai
+ [...]
+RUN ln -snf /usr/share/zoneinfo/$TIME_ZONE /etc/localtime && echo $TIME_ZONE > /etc/timezone \
+    && dpkg-reconfigure -f noninteractive tzdata \
+ [...] 
+```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can also set the `TZ` environment variable to the desired timezone.
 The next command is run on a machine using the `Europe/Paris` timezone a few seconds after the previous one.
 
 ```bash
-$ docker run --rm -ti --env TZ=Asia/Shanghai --entrypoint=date jenkins/agent
+docker run --rm --tty --interactive --env TZ=Asia/Shanghai --entrypoint=date jenkins/agent
 Sat Nov 26 01:27:58 CST 2022 
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you want to use the timezone of your machine, you can mount the `/etc/localti
 In this example, the machine is using the `Europe/Paris` timezone.
 
 ```bash
-$ docker run --rm -ti --entrypoint=date -v /etc/localtime:/etc/localtime:ro -v /etc/timezone:/etc/timezone:ro jenkins/agent
+docker run --rm --tty --interactive --entrypoint=date --volume=/etc/localtime:/etc/localtime:ro --volume=/etc/timezone:/etc/timezone:ro jenkins/agent
 Fri Nov 25 18:27:22 CET 2022
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ See the full list [here](https://hub.docker.com/r/jenkins/agent/tags)
 
 ## Timezones
 
-By default, the image is using the `Etc/UTC` timezone. Should you want to adapt it to your local timezone while creating your own image based on `jenkins/agent`, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
+By default, the image is using the `Etc/UTC` timezone.
+Should you want to adapt it to your local timezone while creating your own image based on `jenkins/agent`, you could use the following command (inspired by issue #[291](https://github.com/jenkinsci/docker-inbound-agent/issues/291)):
 
 ```dockerfile
 FROM jenkins/agent as agent

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ See the full list [here](https://hub.docker.com/r/jenkins/agent/tags)
 ### Using directly the `jenkins/agent` image
 
 By default, the image is using the `Etc/UTC` timezone.
-If you want to use your timezone of your machine, you can mount the `/etc/localtime` file from the host (as per [this comment](https://github.com/moby/moby/issues/12084#issuecomment-89697533)).
+If you want to use the timezone of your machine, you can mount the `/etc/localtime` file from the host (as per [this comment](https://github.com/moby/moby/issues/12084#issuecomment-89697533)) and the `/etc/timezone` from the host too.
 In this example, the machine is using the `Europe/Paris` timezone.
 
 ```bash
-$ docker run --rm -ti --entrypoint=date -v /etc/localtime:/etc/localtime:ro jenkins/agent
+$ docker run --rm -ti --entrypoint=date -v /etc/localtime:/etc/localtime:ro -v /etc/timezone:/etc/timezone:ro jenkins/agent
 Fri Nov 25 18:27:22 CET 2022
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Should you want to adapt it to your local timezone while creating your own image
 ```dockerfile
 FROM jenkins/agent as agent
  [...]
-ENV TIME_ZONE=Asia/Shanghai
+ENV TZ=Asia/Shanghai
  [...]
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
     && dpkg-reconfigure -f noninteractive tzdata \

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ FROM jenkins/agent as agent
  [...]
 ENV TZ=Asia/Shanghai
  [...]
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+RUN ln -snf /usr/share/zoneinfo/"${TZ}" /etc/localtime && echo "${TZ}" > /etc/timezone \
     && dpkg-reconfigure -f noninteractive tzdata \
  [...] 
 ```


### PR DESCRIPTION
By default, the image is using `Etc/UTC`. A user wants to use another timezone (c.f. [#291](https://github.com/jenkinsci/docker-inbound-agent/issues/291).

I explain briefly how to use another one while creating a new image derived from `jenkins/agent`.

This is a follow-up to #337 where I added the `tzdata` package.
This PR and the #337 will replace my first attempt (see #334).
<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
