### PR TITLE
fix(alpine) Alpine 3.17 `tzdata` package doesn't contain `zdump` anymore

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -46,6 +46,7 @@ RUN apk add --no-cache \
      openssl \
      procps \
      tzdata \
+     tzdata-utils \
     && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
 ARG VERSION=3077.vd69cf116da_6f

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -47,6 +47,7 @@ RUN apk add --no-cache \
       openssl \
       procps \
       tzdata \
+      tzdata-utils \
     && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
 ARG VERSION=3077.vd69cf116da_6f


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
With the latest (#341 #342 and #343) the tests regarding `tzdata` [failed](https://github.com/jenkinsci/docker-agent/pull/343/checks?check_run_id=10031726733) for Alpine Linux:

```bash
jenkinsci.docker.alpine_jdk11.Default.#8 [docker.io/jenkins/agent:alpine] 'tzdata' is correctly installed
jenkinsci.docker.alpine_jdk17.Default.#8 [docker.io/jenkins/agent:alpine-jdk17] 'tzdata' is correctly installed
```

In the [Dockerfile](https://github.com/jenkinsci/docker-agent/blob/master/11/alpine/Dockerfile#L24) we build the image from `eclipse-temurin:11.0.17_8-jdk-alpine`. This version now uses Alpine `3.17` and no more `3.16`.

In Alpine `3.16` the `tzdata` package used to contain the `zdump` binary we're using in our tests.
In Alpine `3.17` it has moved to the `tzdata-utils` package.

When this is merged, it should allow #341 #342 and #343 to build.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
