### PR TITLE
chore(updatecli) change deprecated directives with v0.40.x

### DIFF
--- a/updatecli/updatecli.d/bats.yaml
+++ b/updatecli/updatecli.d/bats.yaml
@@ -37,9 +37,9 @@ targets:
         git clone --branch {{ source "lastVersion" }} https://github.com/bats-core/bats-core ./bats
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump bats version to {{ source "lastVersion" }}
     spec:

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -110,9 +110,9 @@ targets:
         matcher: JAVA_VERSION
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump JDK11 version to {{ source "lastVersion" }}
     spec:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -101,9 +101,9 @@ targets:
         matcher: JAVA_VERSION
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump JDK17 version to {{ source "lastVersion" }}
     spec:

--- a/updatecli/updatecli.d/remoting.yaml
+++ b/updatecli/updatecli.d/remoting.yaml
@@ -156,9 +156,9 @@ targets:
         REMOTING_VERSION={{ source "lastVersion" }}
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump the Jenkins remoting version to {{ source "lastVersion" }}
     spec:


### PR DESCRIPTION
As per https://github.com/updatecli/updatecli/releases/tag/v0.40.0, the directive `pullrequests` in updatecli is deprecated in favor of `actions`, along with their `kind` namings.

This PR changes the manifests to remove depreciation messages. Nothing functional.