### PR TITLE
chore(windows) track git version using updatecli and manages all windows patches

### DIFF
--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -44,7 +44,7 @@ ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
-    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    if($env:GIT_PATCH_VERSION -eq 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
     else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `

--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -43,7 +43,9 @@ USER ContainerAdministrator
 ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
+    # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
+    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -30,7 +30,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
+    # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
+    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -31,7 +31,7 @@ ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
-    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    if($env:GIT_PATCH_VERSION -eq 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
     else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -44,7 +44,7 @@ ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
-    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    if($env:GIT_PATCH_VERSION -eq 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
     else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -43,7 +43,9 @@ USER ContainerAdministrator
 ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
+    # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
+    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -30,7 +30,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION) ; `
+    # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
+    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -31,7 +31,7 @@ ARG GIT_VERSION=2.39.1
 ARG GIT_PATCH_VERSION=1
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     # The patch "windows.1" always have a different URL than the subsequent patch (ZIP filename is different)
-    if($env:GIT_PATCH_VERSION = 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
+    if($env:GIT_PATCH_VERSION -eq 1) { $url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION); } `
     else {$url = $('https://github.com/git-for-windows/git/releases/download/v{0}.windows.{1}/MinGit-{0}.{1}-64-bit.zip' -f $env:GIT_VERSION, $env:GIT_PATCH_VERSION)} ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'mingit.zip' -UseBasicParsing ; `

--- a/updatecli/updatecli.d/git-windows.yml
+++ b/updatecli/updatecli.d/git-windows.yml
@@ -1,0 +1,151 @@
+---
+name: Bump Git version on Windows
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Git version
+    spec:
+      owner: "git-for-windows"
+      repository: "git"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        ## Latest stable v{x.y.z}.windows.<patch>
+        pattern: 'v(\d*)\.(\d*)\.(\d*)\.windows\.(\d*)$'
+    transformers:
+      - trimprefix: "v"
+
+targets:
+  ############# JDK11 Nanoserver 18.09
+  setGitVersionJDK11WindowsNanoserver1809:
+    name: Update the Git Windows version for JDK11 Windows Nanoserver 1809
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: 11/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitPackagePatchJDK11WindowsNanoserver1809:
+    name: Update the Git Package Windows patch for JDK11 Windows Nanoserver 1809
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: 11/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+  ############# JDK11 Windows Server Core LTSC2019
+  setGitVersionJDK11WindowsServer2019:
+    name: Update the Git Windows version for JDK11 Windows Server Core LTSC2019
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitPackagePatchJDK11WindowsServer2019:
+    name: Update the Git Package Windows patch for Windows Server Core LTSC2019
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+  ############# JDK17 Nanoserver 18.09
+  setGitVersionJDK17WindowsNanoserver1809:
+    name: Update the Git Windows version for JDK17 Windows Nanoserver 1809
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: 17/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitPackagePatchJDK17WindowsNanoserver1809:
+    name: Update the Git Package Windows patch for JDK17 Windows Nanoserver 1809
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: 17/windows/nanoserver-1809/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+  ############# JDK17 Windows Server Core LTSC2019
+  setGitVersionJDK17WindowsServer2019:
+    name: Update the Git Windows version for JDK17 Windows Server Core LTSC2019
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 1
+    kind: dockerfile
+    spec:
+      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_VERSION
+    scmid: default
+  setGitPackagePatchJDK17WindowsServer2019:
+    name: Update the Git Package Windows patch for JDK17 Windows Server Core LTSC2019
+    transformers:
+      - findsubmatch:
+          pattern: '(.*).windows\.(\d*)$'
+          captureindex: 2
+    kind: dockerfile
+    spec:
+      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GIT_PATCH_VERSION
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump Git version on Windows to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - git
+        - windows


### PR DESCRIPTION
This PR enable `updatecli` to track version of `git` for Windows images only.
It should automate pull requests such as #369 in the future (only human review would be required).

Please note that the image code had to be changed in order to support the 2 kinds of download URL available for the official Git SCM:
- If the "windows patch" is `1`, then the download filename does not have any mention of the patch (for instance version `2.39.1` with patch `1` is `MinGit-2.39.1-64-bit.zip`).
- If the "windows patch " is 2 or more, then the filename has the patch as the 4th digit (for instance version `2.39.0` with patch `2` is `MinGit-2.39.0.2-64-bit.zip`).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
