### PR TITLE
fix(tests) install (non-interactively) Nuget provider as a pre-requisite for Pester installation

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -120,6 +120,7 @@ if($target -eq "test") {
 
     # Only fail the run afterwards in case of any test failures
     $testFailed = $false
+    Get-PackageProvider NuGet -ForceBootstrap
     $mod = Get-InstalledModule -Name Pester -MinimumVersion 5.3.0 -MaximumVersion 5.3.3 -ErrorAction SilentlyContinue
     if($null -eq $mod) {
         $module = "c:\Program Files\WindowsPowerShell\Modules\Pester"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3508

This PR ensures, on Windows only, during the test phase, that the `NuGet` package provider is installed as a pre-requisite for `Pester` framework.

The "subtle" part is that it requires the flag `-ForceBootstrap` because it's run non interactively in the CI environment.


The Infra team will add the `Nuget` installation in the next iteration of the ci.jenkins.io agent Vm template, but it won't kill to have this instruction also part of the `build.ps1`.

If we decide to merge this change, I'll take care of cherry-picking to other Docker images