### PR TITLE
feat: expose default image user to the environment variable `user`

### DIFF
--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-
+ENV user=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/11/archlinux/Dockerfile
+++ b/11/archlinux/Dockerfile
@@ -65,7 +65,7 @@ RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-
+ENV user=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/11/bullseye/Dockerfile
+++ b/11/bullseye/Dockerfile
@@ -82,7 +82,7 @@ RUN mkdir /home/${user}/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-
+ENV user=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -98,7 +98,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}/.jenkins"
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-
+ENV user=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/11/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/11/windows/windowsservercore-ltsc2019/Dockerfile
@@ -84,7 +84,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}/.jenkins"
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-
+ENV user=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/17/alpine/Dockerfile
+++ b/17/alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-
+ENV user=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -91,7 +91,7 @@ RUN mkdir /home/${user}/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-
+ENV user=${user}
 LABEL \
   org.opencontainers.image.vendor="Jenkins project" \
   org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/17/windows/nanoserver-1809/Dockerfile
+++ b/17/windows/nanoserver-1809/Dockerfile
@@ -98,7 +98,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-
+ENV user=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/17/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/17/windows/windowsservercore-ltsc2019/Dockerfile
@@ -84,7 +84,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-
+ENV user=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -80,10 +80,16 @@ Describe "[$global:JDK $global:FLAVOR] image has correct applications in the PAT
         }
     }
 
-    It 'has AGENT_WORKDIR in the envrionment' {
+    It 'has AGENT_WORKDIR in the environment' {
         $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -C `"Get-ChildItem env:`""
         $exitCode | Should -Be 0
         $stdout.Trim() | Should -Match "AGENT_WORKDIR.*C:/Users/jenkins/Work"
+    }
+
+    It 'has user in the environment' {
+        $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "exec $global:AGENT_CONTAINER $global:SHELL -C `"Get-ChildItem env:`""
+        $exitCode | Should -Be 0
+        $stdout.Trim() | Should -Match "user.*jenkins"
     }
 
     AfterAll {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -169,3 +169,7 @@ docker buildx bake \
 
   cleanup "$cid"
 }
+
+@test "[${SUT_IMAGE}] default user is exposed in the environment" {
+  docker inspect --format '{{ .Config.Env }}' "${SUT_IMAGE}" | grep 'user=jenkins'
+}


### PR DESCRIPTION
Caught by https://github.com/jenkinsci/docker-inbound-agent/pull/340, the environment variable `user` is absent for the `jenkins/agent` base image.

Exposing it in the image metadata allows users, building from this image, to switch back and forth between `root` (or `ContainerAdministrator` on Windows) in their `Dockerfile`.

Also added test on both Linux and Windows for this.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
