### PR TITLE
chore(windows) rely on docker-compose for test phase

### DIFF
--- a/build-windows.yaml
+++ b/build-windows.yaml
@@ -1,23 +1,25 @@
-version: '3'
-
 services:
   jdk11-nanoserver-1809:
+    image: jdk11-nanoserver-1809
     build:
       context: ./11/windows/nanoserver-1809/
       args:
-        - VERSION=$REMOTING_VERSION
+        VERSION: ${REMOTING_VERSION}
   jdk17-nanoserver-1809:
+    image: jdk17-nanoserver-1809
     build:
       context: ./17/windows/nanoserver-1809/
       args:
-        - VERSION=$REMOTING_VERSION
+        VERSION: ${REMOTING_VERSION}
   jdk11-windowsservercore-ltsc2019:
+    image: jdk11-windowsservercore-ltsc2019
     build:
       context: ./11/windows/windowsservercore-ltsc2019/
       args:
-        - VERSION=$REMOTING_VERSION
+        VERSION: ${REMOTING_VERSION}
   jdk17-windowsservercore-ltsc2019:
+    image: jdk17-windowsservercore-ltsc2019
     build:
       context: ./17/windows/windowsservercore-ltsc2019/
       args:
-        - VERSION=$REMOTING_VERSION
+        VERSION: ${REMOTING_VERSION}


### PR DESCRIPTION
This PR is an extract of https://github.com/jenkinsci/docker-agent/pull/409 + custom adjustments

Its goal is to update the windows tooling to:

- Get the image to build from `docker-compose` instead of searching for `Dockerfile` recursively
- Increase separation of concerns and efficiency: 
    - Delegates build to `docker-compose` even when building only one image
    - Utilizes `docker tag` after the build instead of rebuilding (even if cached)

- Cleanup code:
    - Remove deprecated or unused directives
    - Factorize code

### Testing done

* on my local machine, ran the command `.\build.ps1 -Target test` to test "all" + CI checks
* on my local machine, ran the commands `.\build.ps1 -Target test -Build jdk11-nanoserver-1809`, `.\build.ps1 -Target test -Build jdk17-nanoserver-1809`, `.\build.ps1 -Target test -Build jdk11-windowsservercore-ltsc2019` and `.\build.ps1 -Target test -Build jdk17-windowsservercore-ltsc2019` to validate the build and run executes only for the specified image

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
