### PR TITLE
Label Alpine container with correct version number

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -62,7 +62,7 @@ variable "ON_TAG" {
 }
 
 variable "ALPINE_FULL_TAG" {
-  default = "3.16.2"
+  default = "3.17.3"
 }
 
 variable "ALPINE_SHORT_TAG" {


### PR DESCRIPTION
## Label Alpine container with correct version

The Alpine container image uses the Alpine version that is provided by the Elclipse Temurin Alpine container image.  That container image was upgraded from 3.16 to 3.17 months ago.  We didn't detect that version upgrade. We don't have a test that checks the Alpine version matches the tag we are creating on Dockerhub.

This is a short term solution, since it doesn't add any check to verify the Alpine version included in the Eclipse Temurin Alpine container matches the version we use to create the Dockerhub tag.

Since Alpine 3.18.0 has released, we can expect that the next Eclipse Temurin update (11.0.20, 17.0.8) in about 3 months will deliver Alpine 3.18.0 instead of 3.17.3.

Fixes https://github.com/jenkinsci/docker-agent/issues/415

### Testing done

Confirmed that Alpine 3.17 is included in the Temurin package and that the label written to Dockerhub is extracted from the variable in the bake file.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
