### PR TITLE
chore(updatecli) fix JDK version tracking - fixup of #409

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -69,11 +69,19 @@ variable "ALPINE_SHORT_TAG" {
   default = regex_replace(ALPINE_FULL_TAG, "\\.\\d+$", "")
 }
 
+variable "JAVA11_VERSION" {
+  default = "11.0.19_7"
+}
+
+variable "JAVA17_VERSION" {
+  default = "17.0.7_7"
+}
+
 target "archlinux_jdk11" {
   dockerfile = "archlinux/Dockerfile"
   context = "."
   args = {
-    JAVA_VERSION = "11.0.19_7"
+    JAVA_VERSION = JAVA11_VERSION
     VERSION = REMOTING_VERSION
   }
   tags = [
@@ -92,7 +100,7 @@ target "alpine_jdk11" {
   context = "."
   args = {
     ALPINE_TAG = ALPINE_FULL_TAG
-    JAVA_VERSION = "11.0.19_7"
+    JAVA_VERSION = JAVA11_VERSION
     VERSION = REMOTING_VERSION
   }
   tags = [
@@ -117,7 +125,7 @@ target "alpine_jdk17" {
   context = "."
   args = {
     ALPINE_TAG = ALPINE_FULL_TAG
-    JAVA_VERSION = "17.0.7_7"
+    JAVA_VERSION = JAVA17_VERSION
     VERSION = REMOTING_VERSION
   }
   tags = [
@@ -135,7 +143,7 @@ target "debian_jdk11" {
   dockerfile = "debian/Dockerfile"
   context = "."
   args = {
-    JAVA_VERSION = "11.0.19_7"
+    JAVA_VERSION = JAVA11_VERSION
     VERSION = REMOTING_VERSION
   }
   tags = [
@@ -154,7 +162,7 @@ target "debian_jdk17" {
   dockerfile = "debian/Dockerfile"
   context = "."
   args = {
-    JAVA_VERSION = "17.0.7_7"
+    JAVA_VERSION = JAVA17_VERSION
     VERSION = REMOTING_VERSION,
   }
   tags = [

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -64,50 +64,29 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
 
 targets:
-  setJDK11VersionAlpine:
-    name: "Bump JDK11 version on Alpine image"
-    kind: dockerfile
+  setJDK11VersionDockerBake:
+    name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
+    kind: file
     spec:
-      file: 11/alpine/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionDebian:
-    name: "Bump JDK11 version on Debian image"
-    kind: dockerfile
-    spec:
-      file: 11/bullseye/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionArch:
-    name: "Bump JDK11 version on Archlinux image"
-    kind: dockerfile
-    spec:
-      file: 11/archlinux/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"JAVA11_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"JAVA11_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
     scmid: default
   setJDK11VersionWindowsNanoserver1809:
     name: "Bump JDK11 version on Windows Nanoserver 1809 image"
-    kind: dockerfile
+    kind: yaml
     spec:
-      file: 11/windows/nanoserver-1809/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
+      file: build-windows.yaml
+      key: services.jdk11-nanoserver-1809.build.args.JAVA_VERSION
     scmid: default
   setJDK11VersionWindowsServerLtsc2019:
     name: "Bump JDK11 version on Windows Server LTSC 2019 image"
-    kind: dockerfile
+    kind: yaml
     spec:
-      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
+      file: build-windows.yaml
+      key: services.jdk11-windowsservercore-ltsc2019.build.args.JAVA_VERSION
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -64,41 +64,47 @@ conditions:
       tag: '{{source "lastVersion" }}-jdk-windowsservercore-1809'
 
 targets:
+  setJDK17VersionDockerBake:
+    name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
+    kind: file
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"JAVA17_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+    scmid: default
   setJDK17VersionAlpine:
-    name: "Bump JDK17 version on Alpine image"
+    name: "Bump JDK17 default ARG version on Alpine Dockerfile"
     kind: dockerfile
     spec:
-      file: 17/alpine/Dockerfile
+      file: alpine/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
   setJDK17VersionDebian:
-    name: "Bump JDK17 version on Debian image"
+    name: "Bump JDK17 default ARG version on Debian Dockerfile"
     kind: dockerfile
     spec:
-      file: 17/bullseye/Dockerfile
+      file: debian/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
   setJDK17VersionWindowsNanoserver1809:
     name: "Bump JDK17 version on Windows Nanoserver 1809 image"
-    kind: dockerfile
+    kind: yaml
     spec:
-      file: 17/windows/nanoserver-1809/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
+      file: build-windows.yaml
+      key: services.jdk17-nanoserver-1809.build.args.JAVA_VERSION
     scmid: default
   setJDK17VersionWindowsServerLtsc2019:
     name: "Bump JDK17 version on Windows Server LTSC 2019 image"
-    kind: dockerfile
+    kind: yaml
     spec:
-      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
+      file: build-windows.yaml
+      key: services.jdk17-windowsservercore-ltsc2019.build.args.JAVA_VERSION
     scmid: default
 
 actions:


### PR DESCRIPTION
This PR follows up #409 to fix the updatecli manifest which tracks the JDK versions.

As HCL is not supported out of the box by updatecli (ref. https://github.com/updatecli/updatecli/issues/534), I've factorized the JAVA_VERSION in the `docker-bake.hcl` file to allow easier file regexp matching.

### Testing done

The updatecli check will fail on this PR, for both JDK11 and JDK17 manifest, because [updatecli only check against the remote principal branch](https://github.com/updatecli/updatecli/issues/465) instead of the local change. Since `docker-bake.hcl` was changed, it won't see the changed version.

So I tested locally by commenting out the `scmid: ` key of the failing targetn which gave me the following results:

<details>
<summary>Click to see JDK11 result</summary>

```console
TARGETS
========

setJDK11VersionWindowsServerLtsc2019
------------------------------------

**Dry Run enabled**

✔ Key 'services.jdk11-windowsservercore-ltsc2019.build.args.JAVA_VERSION', from file '/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/build-windows.yaml', already set to 11.0.19_7, nothing else need to be done

setJDK11VersionWindowsNanoserver1809
------------------------------------

**Dry Run enabled**

✔ Key 'services.jdk11-nanoserver-1809.build.args.JAVA_VERSION', from file '/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/build-windows.yaml', already set to 11.0.19_7, nothing else need to be done

setJDK11VersionDockerBake
-------------------------

**Dry Run enabled**

✔ Content from file "docker-bake.hcl" already up to date
✔ All contents from 'file' and 'files' combined already up to date


ACTIONS
========


=============================

REPORTS:


✔ Bump JDK11 version:
        Source:
                ✔ [lastVersion] Get the latest Adoptium JDK11 version (kind: githubrelease)
        Condition:
                ✔ [checkTemurinAlpineDockerImage] Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available (kind: dockerimage)
                ✔ [checkTemurinDebianDockerImages] Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available (kind: dockerimage)
                ✔ [checkTemurinWindowsCoreDockerImage] Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available (kind: dockerimage)
        Target:
                ✔ [setJDK11VersionDockerBake] Bump JDK11 version for Linux images in the docker-bake.hcl file (kind: file)
                ✔ [setJDK11VersionWindowsNanoserver1809] Bump JDK11 version on Windows Nanoserver 1809 image (kind: yaml)
                ✔ [setJDK11VersionWindowsServerLtsc2019] Bump JDK11 version on Windows Server LTSC 2019 image (kind: yaml)


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```

</details>

<details>
<summary>Click to see JDK17 result</summary>

```console
TARGETS
========

setJDK17VersionWindowsServerLtsc2019
------------------------------------

**Dry Run enabled**

✔ Key 'services.jdk17-windowsservercore-ltsc2019.build.args.JAVA_VERSION', from file '/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/build-windows.yaml', already set to 17.0.7_7, nothing else need to be done

setJDK17VersionWindowsNanoserver1809
------------------------------------

**Dry Run enabled**

✔ Key 'services.jdk17-nanoserver-1809.build.args.JAVA_VERSION', from file '/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/build-windows.yaml', already set to 17.0.7_7, nothing else need to be done

setJDK17VersionDebian
---------------------

**Dry Run enabled**


🐋 On (Docker)file "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/debian/Dockerfile":

✔ The line #23, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=17.0.7_7".

setJDK17VersionAlpine
---------------------

**Dry Run enabled**


🐋 On (Docker)file "/var/folders/2s/09szbrgn22l2tcvxz1_k34g40000gn/T/updatecli/github/jenkinsci/docker-agent/alpine/Dockerfile":

✔ The line #22, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=17.0.7_7".

setJDK17VersionDockerBake
-------------------------

**Dry Run enabled**

✔ Content from file "docker-bake.hcl" already up to date
✔ All contents from 'file' and 'files' combined already up to date


ACTIONS
========


=============================

REPORTS:


✔ Bump JDK17 version:
        Source:
                ✔ [lastVersion] Get the latest Adoptium JDK17 version (kind: githubrelease)
        Condition:
                ✔ [checkTemurinAlpineDockerImage] Check if the container image "eclipse-temurin:<lastVersion>-jdk-alpine" is available (kind: dockerimage)
                ✔ [checkTemurinDebianDockerImages] Check if the container image "eclipse-temurin:<lastVersion>-jdk-focal" is available (kind: dockerimage)
                ✔ [checkTemurinWindowsCoreDockerImage] Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available (kind: dockerimage)
        Target:
                ✔ [setJDK17VersionAlpine] Bump JDK17 default ARG version on Alpine Dockerfile (kind: dockerfile)
                ✔ [setJDK17VersionDebian] Bump JDK17 default ARG version on Debian Dockerfile (kind: dockerfile)
                ✔ [setJDK17VersionDockerBake] Bump JDK17 version for Linux images in the docker-bake.hcl file (kind: file)
                ✔ [setJDK17VersionWindowsNanoserver1809] Bump JDK17 version on Windows Nanoserver 1809 image (kind: yaml)
                ✔ [setJDK17VersionWindowsServerLtsc2019] Bump JDK17 version on Windows Server LTSC 2019 image (kind: yaml)


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```

</details>

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
