### PR TITLE
add ksalerno99 as code owner for the debian Dockerfile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @jenkinsci/team-docker-packaging
+*/debian @ksalerno99


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/docker/pull/1632 and #391 

As per https://github.com/jenkinsci/docker/issues/1559#issuecomment-1453514549, @ksalerno99 stepped-in to help to add the ppc64le architecture on this image (and also Docker agents).

This PR adds as a (co-) code owner for the debian images (ref #391)

Many thanks for the contributions and help!

Once merged, i'll take care of adding @ksalerno99 in the repository as contributor.