### PR TITLE
chore: fix Dockerfile location on the last items - fixup of #409

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,7 @@ updates:
 # Windows
 
 - package-ecosystem: docker
-  directory: "17/windows/nanoserver-1809"
+  directory: "windows/nanoserver-1809"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -77,7 +77,7 @@ updates:
   - dependencies
 
 - package-ecosystem: docker
-  directory: "17/windows/windowsservercore-ltsc2019"
+  directory: "windows/windowsservercore-ltsc2019"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -88,7 +88,7 @@ updates:
   - dependencies
 
 - package-ecosystem: docker
-  directory: "11/windows/nanoserver-1809"
+  directory: "windows/nanoserver-1809"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -99,7 +99,7 @@ updates:
   - dependencies
 
 - package-ecosystem: docker
-  directory: "11/windows/windowsservercore-ltsc2019"
+  directory: "windows/windowsservercore-ltsc2019"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2

--- a/updatecli/updatecli.d/git-windows.yml
+++ b/updatecli/updatecli.d/git-windows.yml
@@ -39,7 +39,7 @@ targets:
           captureindex: 1
     kind: dockerfile
     spec:
-      file: 11/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_VERSION
@@ -52,7 +52,7 @@ targets:
           captureindex: 2
     kind: dockerfile
     spec:
-      file: 11/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_PATCH_VERSION
@@ -66,7 +66,7 @@ targets:
           captureindex: 1
     kind: dockerfile
     spec:
-      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_VERSION
@@ -79,7 +79,7 @@ targets:
           captureindex: 2
     kind: dockerfile
     spec:
-      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_PATCH_VERSION
@@ -93,7 +93,7 @@ targets:
           captureindex: 1
     kind: dockerfile
     spec:
-      file: 17/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_VERSION
@@ -106,7 +106,7 @@ targets:
           captureindex: 2
     kind: dockerfile
     spec:
-      file: 17/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_PATCH_VERSION
@@ -120,7 +120,7 @@ targets:
           captureindex: 1
     kind: dockerfile
     spec:
-      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_VERSION
@@ -133,7 +133,7 @@ targets:
           captureindex: 2
     kind: dockerfile
     spec:
-      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_PATCH_VERSION

--- a/updatecli/updatecli.d/remoting.yaml
+++ b/updatecli/updatecli.d/remoting.yaml
@@ -34,29 +34,29 @@ conditions:
       command: curl --silent --show-error --location --verbose --output /dev/null --fail https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/{{ source "lastVersion" }}/remoting-{{ source "lastVersion" }}.jar
 
 targets:
-  setJdk11AlpineDockerImage:
+  setAlpineDockerImage:
     name: Bump the Jenkins remoting version on JDK11 Alpine
     kind: dockerfile
     spec:
-      file: 11/alpine/Dockerfile
+      file: alpine/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
     scmid: default
-  setJdk11ArchlinuxDockerImage:
+  setArchlinuxDockerImage:
     name: Bump the Jenkins remoting version on JDK11 Archlinux
     kind: dockerfile
     spec:
-      file: 11/archlinux/Dockerfile
+      file: archlinux/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
     scmid: default
-  setJdk11DebianDockerImage:
+  setDebianDockerImage:
     name: Bump the Jenkins remoting version on JDK11 Debian Bullseye
     kind: dockerfile
     spec:
-      file: 11/bullseye/Dockerfile
+      file: debian/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
@@ -65,7 +65,7 @@ targets:
     name: Bump the Jenkins remoting version on JDK11 Windows Nanoserver 1809
     kind: dockerfile
     spec:
-      file: 11/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
@@ -74,25 +74,7 @@ targets:
     name: Bump the Jenkins remoting version on JDK11 Windows Server 2019
     kind: dockerfile
     spec:
-      file: 11/windows/windowsservercore-ltsc2019/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: VERSION
-    scmid: default
-  setJdk17AlpineDockerImage:
-    name: Bump the Jenkins remoting version on JDK17 Alpine
-    kind: dockerfile
-    spec:
-      file: 17/alpine/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: VERSION
-    scmid: default
-  setJdk17DebianDockerImage:
-    name: Bump the Jenkins remoting version on JDK17 Debian Bullseye
-    kind: dockerfile
-    spec:
-      file: 17/bullseye/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
@@ -101,7 +83,7 @@ targets:
     name: Bump the Jenkins remoting version on JDK17 Windows Nanoserver 1809
     kind: dockerfile
     spec:
-      file: 17/windows/nanoserver-1809/Dockerfile
+      file: windows/nanoserver-1809/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION
@@ -110,7 +92,7 @@ targets:
     name: Bump the Jenkins remoting version on JDK17 Windows Server 2019
     kind: dockerfile
     spec:
-      file: 17/windows/windowsservercore-ltsc2019/Dockerfile
+      file: windows/windowsservercore-ltsc2019/Dockerfile
       instruction:
         keyword: ARG
         matcher: VERSION


### PR DESCRIPTION
As part of #409, the location of the `Dockerfile` were changed.

Despite #418 , there still had components with invalid locations: this PR aims at fixing them:

- Dependabot
- Updatecli manifest for the git version (causing build failures in GHA)
- Updatecli manifest for the remoting version (causing build failures in GHA)

