### PR TITLE
chore(alpine): Uses `updatecli` to stay up to date

### DIFF
--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -1,0 +1,68 @@
+---
+name: Bump Alpine version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: "Get the latest Alpine Linux version"
+    spec:
+      owner: "alpinelinux"
+      repository: "aports" # Its release process follows Alpine's
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+        pattern: "~3"
+    transformers:
+      - trimprefix: "v"
+
+conditions:
+  testDockerfileArg:
+    name: "Does the Dockerfile have an ARG instruction for the Alpine Linux version?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: alpine/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "ALPINE_TAG"
+  testDockerImageExists:
+    name: "Does the Docker Image exist on the Docker Hub?"
+    kind: dockerimage
+    sourceid: latestVersion
+    spec:
+      image: "alpine"
+      # tag come from the source
+      architecture: amd64
+
+targets:
+  updateDockerfile:
+    name: "Update the value of the base image (ARG ALPINE_TAG) in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: alpine/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "ALPINE_TAG"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Alpine Linux Version to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -57,7 +57,16 @@ targets:
         keyword: "ARG"
         matcher: "ALPINE_TAG"
     scmid: default
-
+  updateDockerBake:
+    name: "Update the value of the base image (ARG ALPINE_TAG) in the docker-bake.hcl"
+    kind: file
+    spec:
+      file: docker-bake.hcl
+      matchpattern: >-
+        variable(.*)"ALPINE_FULL_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+      replacepattern: >-
+        variable${1}"ALPINE_FULL_TAG"${2}{${3}${4}${5}default${6}= "{{ source "latestVersion" }}"
+    scmid: default
 actions:
   default:
     kind: github/pullrequest


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`updatecli/updatecli.d/alpine.yaml` now checks for a `3.x` update for Alpine, with the help of github then docker hub.

This is a work in progress, thanks to the guidance from @dduportal, after #421 (and more specifically in his [comment](https://github.com/jenkinsci/docker-agent/pull/421#issuecomment-1552674986)).
The main target has not been reached yet, as we're only changing values in `alpine/Dockerfile`, which is nice, but not enough.
We have to change the value in `docker-bake.hcl`, which is not the case yet. I will have to investigate.

### Testing done

I've used a dry run and it detected a new version:

```bash
updatecli diff --config updatecli/updatecli.d/alpine.yaml --values updatecli/values.github-action.yaml

+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/alpine.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#######################
# BUMP ALPINE VERSION #
#######################


SOURCES
=======

latestVersion
-------------
WARNING: ⚠ No GitHub Release found, we fallback to published git tags
Searching for version matching pattern "~3"
✔ Github Release version "v3.18.0" found matching pattern "~3"


CHANGELOG:
----------
no GitHub Release found for v3.18.0 on "https://github.com/alpinelinux/aports"


CONDITIONS:
===========

testDockerfileArg
-----------------

🐋 On (Docker)file "alpine/Dockerfile":

✔ Line "ARG ALPINE_TAG=3.17.3" found, matching the keyword "ARG" and the matcher "ALPINE_TAG".

testDockerImageExists
---------------------
✔ The Docker image index.docker.io/library/alpine:3.18.0 (amd64) exists and is available.


TARGETS
========

updateDockerfile
----------------

**Dry Run enabled**


🐋 On (Docker)file "/tmp/updatecli/github/jenkinsci/docker-agent/alpine/Dockerfile":

⚠ The line #23, matched by the keyword "ARG" and the matcher "ALPINE_TAG", is changed from "ARG ALPINE_TAG=3.17.3" to "ARG ALPINE_TAG=3.18.0".
⚠ The line #43, matched by the keyword "ARG" and the matcher "ALPINE_TAG", is changed from "ARG ALPINE_TAG=3.17.3" to "ARG ALPINE_TAG=3.18.0".


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:


⚠ Bump Alpine version:
        Source:
                ✔ [latestVersion] Get the latest Alpine Linux version (kind: githubrelease)
        Condition:
                ✔ [testDockerImageExists] Does the Docker Image exist on the Docker Hub? (kind: dockerimage)
                ✔ [testDockerfileArg] Does the Dockerfile have an ARG instruction for the Alpine Linux version? (kind: dockerfile)
        Target:
                ⚠ [updateDockerfile] Update the value of the base image (ARG ALPINE_TAG) in the Dockerfile (kind: dockerfile)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
``` 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
