### PR TITLE
chore(GHA) bump updatecli action to 2.31.0 (updatecli bumped to 0.53.0)

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.30.0
+        uses: updatecli/updatecli-action@v2.31.0
         with:
           version: v0.46.0
 


### PR DESCRIPTION
This PR bumps updatecli to 0.53.0 (by bumping the GitHub Action to 2.31.0).

Usually Dependabot do this but a faster upgrade would help to solve the errors with Dockerfiles as 0.53.0 embed the following updatecli fix: https://github.com/updatecli/updatecli/pull/1368

Twin of https://github.com/jenkinsci/docker-ssh-agent/pull/257