### PR TITLE
chore(docker): Adds an `archlinux_jdk17` target.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,6 +3,7 @@ group "linux" {
     "alpine_jdk11",
     "alpine_jdk17",
     "archlinux_jdk11",
+    "archlinux_jdk17",
     "debian_jdk11",
     "debian_jdk17",
   ]
@@ -91,6 +92,21 @@ target "archlinux_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:latest-archlinux",
     "${REGISTRY}/${JENKINS_REPO}:archlinux-jdk11",
     "${REGISTRY}/${JENKINS_REPO}:latest-archlinux-jdk11",
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "archlinux_jdk17" {
+  dockerfile = "archlinux/Dockerfile"
+  context = "."
+  args = {
+    JAVA_VERSION = JAVA17_VERSION
+    VERSION = REMOTING_VERSION
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-archlinux-jdk17" : "",
+    "${REGISTRY}/${JENKINS_REPO}:archlinux-jdk17",
+    "${REGISTRY}/${JENKINS_REPO}:latest-archlinux-jdk17",
   ]
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I added a new target in the `docker-bake.hcl` file: `archlinux_jdk17`.
I'm not so sure this is useful, as per the [latest download statistics](https://docs.google.com/spreadsheets/d/1NfGpKDXaRQh1DRD64CG1fY6CoIG9D--H8Ft01VhfzRQ/edit#gid=464701290).

### Testing done

```bash
docker buildx bake archlinux_jdk17
[+] Building 38.2s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 3.21kB                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                             0.1s
 => => transferring context: 2B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/archlinux:base-20230430.0.146624                                                                                           2.1s
 => [internal] load metadata for docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal                                                                                         0.9s
 => [auth] library/eclipse-temurin:pull token for registry-1.docker.io                                                                                                        0.0s
 => [auth] library/archlinux:pull token for registry-1.docker.io                                                                                                              0.0s
 => [stage-1 1/8] FROM docker.io/library/archlinux:base-20230430.0.146624@sha256:e957ad743c49cb95e55d226c946da7416ff3e7cac70d0131db4bf6110cdd8de0                            16.3s
 => => resolve docker.io/library/archlinux:base-20230430.0.146624@sha256:e957ad743c49cb95e55d226c946da7416ff3e7cac70d0131db4bf6110cdd8de0                                     0.0s
 => => sha256:6bd78d2d560350a0a03264bdd6876d985c59e54b717d036e1a1b2883d8021dab 7.95kB / 7.95kB                                                                                0.6s
 => => sha256:05a9396612f13404c7a585cceb964540ec70047e1a3e22b49e3f67f575d162f8 143.10MB / 143.10MB                                                                           13.5s
 => => extracting sha256:05a9396612f13404c7a585cceb964540ec70047e1a3e22b49e3f67f575d162f8                                                                                     2.6s
 => => extracting sha256:6bd78d2d560350a0a03264bdd6876d985c59e54b717d036e1a1b2883d8021dab                                                                                     0.0s
 => CACHED [jre-build 1/2] FROM docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal@sha256:49092a946445870e6e8205043dd54f7e79fb8740a79a4648a3244c7a4a2adb41                  0.1s
 => => resolve docker.io/library/eclipse-temurin:17.0.7_7-jdk-focal@sha256:49092a946445870e6e8205043dd54f7e79fb8740a79a4648a3244c7a4a2adb41                                   0.1s
 => CACHED https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/3131.vf2b_b_798b_ce99/remoting-3131.vf2b_b_798b_ce99.jar                                           1.1s
 => [jre-build 2/2] RUN jlink   --add-modules ALL-MODULE-PATH   --strip-debug   --no-man-pages   --no-header-files   --compress=2   --output /javaruntime                    11.7s
 => [stage-1 2/8] RUN groupadd -g "1000" "jenkins"   && useradd -l -c "Jenkins user" -d /home/"jenkins" -u "1000" -g "1000" -m "jenkins"                                      0.7s
 => [stage-1 3/8] RUN pacman -Syu curl git git-lfs openssh tzdata --noconfirm                                                                                                18.0s
 => [stage-1 4/8] ADD --chown=jenkins:jenkins https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/3131.vf2b_b_798b_ce99/remoting-3131.vf2b_b_798b_ce99.jar /usr/  0.1s
 => [stage-1 5/8] RUN chmod 0644 /usr/share/jenkins/agent.jar   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar                                           0.2s
 => [stage-1 6/8] COPY --from=jre-build /javaruntime /opt/java/openjdk                                                                                                        0.2s
 => [stage-1 7/8] RUN mkdir /home/"jenkins"/.jenkins && mkdir -p "/home/jenkins/agent"                                                                                        0.2s
 => [stage-1 8/8] WORKDIR **/home/jenkins
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
