### PR TITLE
feat: use a multi-stage image for Windows Server Core

### DIFF
--- a/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/windows/windowsservercore-ltsc2019/Dockerfile
@@ -28,6 +28,7 @@ FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-1809 AS jdk-core
 FROM mcr.microsoft.com/powershell:windowsservercore-1809
 
 ARG JAVA_HOME="C:\openjdk-17"
+ENV JAVA_HOME=${JAVA_HOME}
 
 COPY --from=jdk-core $JAVA_HOME $JAVA_HOME
 

--- a/windows/windowsservercore-ltsc2019/Dockerfile
+++ b/windows/windowsservercore-ltsc2019/Dockerfile
@@ -23,7 +23,13 @@
 #  THE SOFTWARE.
 
 ARG JAVA_VERSION=17.0.7_7
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-1809
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-1809 AS jdk-core
+
+FROM mcr.microsoft.com/powershell:windowsservercore-1809
+
+ARG JAVA_HOME="C:\openjdk-17"
+
+COPY --from=jdk-core $JAVA_HOME $JAVA_HOME
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -47,7 +53,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item GitLfs.zip -Force ; `
     & C:\mingit\cmd\git.exe lfs install ; `
     $CurrentPath = (Get-Itemproperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path).Path ; `
-    $NewPath = $CurrentPath + ';C:\mingit\cmd' ; `
+    # Add git and java in PATH
+    $NewPath = $CurrentPath + $(';{0}\bin;C:\mingit\cmd' -f $env:JAVA_HOME) ; `
     Set-ItemProperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path -Value $NewPath
 
 ARG user=jenkins


### PR DESCRIPTION
This PR switches from an `eclipse-temurin` base image to a `powershell:windowsservercore` one, a multi-stage image like it's done for nanoserver.

Note: while all tests are passing, this can potentially be a breaking change.

Close #429 

### Testing done

https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-442/1/pipeline-console/?selected-node=28

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
