### PR TITLE
chore(updatecli) fixups of JDK manifests and remove depreciation warnings

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install Updatecli in the runner
         uses: updatecli/updatecli-action@v2.32.0
-        with:
-          version: v0.46.0
 
       - name: Run Updatecli in Dry Run mode
         run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml

--- a/build-windows.yaml
+++ b/build-windows.yaml
@@ -5,7 +5,7 @@ services:
       context: ./windows/nanoserver/
       args:
         JAVA_HOME: "C:/openjdk-11"
-        JAVA_VERSION: "11.0.19_7"
+        JAVA_VERSION: 11.0.19_7
         VERSION: ${REMOTING_VERSION}
         WINDOWS_VERSION_TAG: ${WINDOWS_VERSION_TAG}
   jdk17-nanoserver:
@@ -14,7 +14,7 @@ services:
       context: ./windows/nanoserver/
       args:
         JAVA_HOME: "C:/openjdk-17"
-        JAVA_VERSION: "17.0.7_7"
+        JAVA_VERSION: 17.0.7_7
         VERSION: ${REMOTING_VERSION}
         WINDOWS_VERSION_TAG: ${WINDOWS_VERSION_TAG}
   jdk11-windowsservercore:
@@ -23,7 +23,7 @@ services:
       context: ./windows/windowsservercore/
       args:
         JAVA_HOME: "C:/openjdk-11"
-        JAVA_VERSION: "11.0.19_7"
+        JAVA_VERSION: 11.0.19_7
         VERSION: ${REMOTING_VERSION}
         WINDOWS_VERSION_TAG: ${WINDOWS_VERSION_TAG}
   jdk17-windowsservercore:
@@ -32,6 +32,6 @@ services:
       context: ./windows/windowsservercore/
       args:
         JAVA_HOME: "C:/openjdk-17"
-        JAVA_VERSION: "17.0.7_7"
+        JAVA_VERSION: 17.0.7_7
         VERSION: ${REMOTING_VERSION}
         WINDOWS_VERSION_TAG: ${WINDOWS_VERSION_TAG}

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -87,14 +87,14 @@ targets:
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: services.jdk11-nanoserver-1809.build.args.JAVA_VERSION
+      key: $.services.jdk11-nanoserver.build.args.JAVA_VERSION
     scmid: default
   setJDK11VersionWindowsServerLtsc2019:
     name: "Bump JDK11 version on Windows Server LTSC 2019 image"
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: services.jdk11-windowsservercore-ltsc2019.build.args.JAVA_VERSION
+      key: $.services.jdk11-windowsservercore.build.args.JAVA_VERSION
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -105,14 +105,14 @@ targets:
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: services.jdk17-nanoserver-1809.build.args.JAVA_VERSION
+      key: $.services.jdk17-nanoserver.build.args.JAVA_VERSION
     scmid: default
   setJDK17VersionWindowsServerLtsc2019:
     name: "Bump JDK17 version on Windows Server LTSC 2019 image"
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: services.jdk17-windowsservercore-ltsc2019.build.args.JAVA_VERSION
+      key: $.services.jdk17-windowsservercore.build.args.JAVA_VERSION
     scmid: default
 
 actions:


### PR DESCRIPTION
Minor fixups of #445 + remove updatecli's depreciation warnings  avoid empty PR due to double quotes