### PR TITLE
chore(tests) fixup build to pass Windows version image tag as build arg for Pester docker tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -96,9 +96,11 @@ Invoke-Expression "$baseDockerCmd config --services" 2>$null | ForEach-Object {
 
     $baseImage = "${windowsType}-${windowsVersion}"
     $versionTag = "${RemotingVersion}-${BuildNumber}-${image}"
+    Write-Host "= PREPARE: Preparing image ${image}, versionTag ${versionTag}"
     $tags = @( $image, $versionTag )
     if($jdkMajorVersion -eq "$defaultJdk") {
         $tags += $baseImage
+        Write-Host "= PREPARE: Bare image tag ${baseImage}"
     }
 
     $builds[$image] = @{
@@ -183,7 +185,7 @@ if($target -eq "test") {
     if(![System.String]::IsNullOrWhiteSpace($Build) -and $builds.ContainsKey($Build)) {
         Test-Image $Build
     } else {
-        Write-Host "= TEST: Testing all images"
+        Write-Host "= TEST: Testing all images..."
         foreach($image in $builds.Keys) {
             Test-Image $image
         }

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -3,6 +3,7 @@ Import-Module -DisableNameChecking -Force $PSScriptRoot/test_helpers.psm1
 $global:AGENT_IMAGE = Get-EnvOrDefault 'AGENT_IMAGE' ''
 $global:IMAGE_FOLDER = Get-EnvOrDefault 'IMAGE_FOLDER' ''
 $global:VERSION = Get-EnvOrDefault 'VERSION' ''
+$global:WINDOWS_VERSION_TAG = Get-EnvOrDefault 'WINDOWS_VERSION_TAG' ''
 
 $items = $global:AGENT_IMAGE.Split("-")
 
@@ -126,7 +127,7 @@ Describe "[$global:AGENT_IMAGE] can be built with custom build arguments" {
     BeforeAll {
         Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" -t ${global:AGENT_IMAGE} ${global:IMAGE_FOLDER}"
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWS_VERSION_TAG}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" -t ${global:AGENT_IMAGE} ${global:IMAGE_FOLDER}"
         $exitCode | Should -Be 0
 
         docker run -d -it --name "$global:CONTAINERNAME" -P "$global:AGENT_IMAGE" "$global:CONTAINERSHELL"

--- a/tests/test_helpers.psm1
+++ b/tests/test_helpers.psm1
@@ -115,7 +115,7 @@ function Run-Program($cmd, $params) {
     $stderr = $proc.StandardError.ReadToEnd()
     $proc.WaitForExit()
     if($proc.ExitCode -ne 0) {
-        Write-Host "`n`nstdout:`n$stdout`n`nstderr:`n$stderr`n$cmd`n`nparams:`n$param`n`n"
+        Write-Host "`n`nstdout:`n$stdout`n`nstderr:`n$stderr`n`ncmd:`n$cmd`n`nparams:`n$param`n`n"
     }
 
     return $proc.ExitCode, $stdout, $stderr

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -54,9 +54,9 @@ conditions:
         - arm/v7
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinNanocore2019DockerImage:
+  checkTemurinNanoserver2019DockerImage:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-nanoserver-1809" is available
     disablesourceinput: true
     spec:
       architecture: amd64
@@ -82,15 +82,15 @@ targets:
       replacepattern: >-
         variable${1}"JAVA11_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
     scmid: default
-  setJDK11VersionWindowsNanoserver1809:
-    name: "Bump JDK11 version on Windows Nanoserver 1809 image"
+  setJDK11VersionWindowsNanoserver:
+    name: "Bump JDK11 version on Windows Nanoserver image"
     kind: yaml
     spec:
       file: build-windows.yaml
       key: $.services.jdk11-nanoserver.build.args.JAVA_VERSION
     scmid: default
-  setJDK11VersionWindowsServerLtsc2019:
-    name: "Bump JDK11 version on Windows Server LTSC 2019 image"
+  setJDK11VersionWindowsServer:
+    name: "Bump JDK11 version on Windows Server image"
     kind: yaml
     spec:
       file: build-windows.yaml

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -54,9 +54,9 @@ conditions:
         - arm/v7
       image: eclipse-temurin
       tag: '{{source "lastVersion" }}-jdk-focal'
-  checkTemurinNanocore2019DockerImage:
+  checkTemurinNanoserver2019DockerImage:
     kind: dockerimage
-    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-windowsservercore-1809" is available
+    name: Check if the container image "eclipse-temurin:<lastVersion>-jdk-nanoserver-1809" is available
     disablesourceinput: true
     spec:
       architecture: amd64
@@ -100,15 +100,15 @@ targets:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-  setJDK17VersionWindowsNanoserver1809:
-    name: "Bump JDK17 version on Windows Nanoserver 1809 image"
+  setJDK17VersionWindowsNanoserver:
+    name: "Bump JDK17 version on Windows Nanoserver image"
     kind: yaml
     spec:
       file: build-windows.yaml
       key: $.services.jdk17-nanoserver.build.args.JAVA_VERSION
     scmid: default
-  setJDK17VersionWindowsServerLtsc2019:
-    name: "Bump JDK17 version on Windows Server LTSC 2019 image"
+  setJDK17VersionWindowsServer:
+    name: "Bump JDK17 version on Windows Server image"
     kind: yaml
     spec:
       file: build-windows.yaml


### PR DESCRIPTION
This PR fixes Pester tests by passing `WINDOWS_VERSION_TAG` env var as build arg in the docker tests. (It would use a 1809 image otherwise, causing the following error: "The container operating system does not match the host operating system.")

It also contains a cleanup of updatecli manifests and debug messages.

Fixup extracted from #441, follow-up of #445

### Testing done

Only this change: https://ci.jenkins.io/job/Packaging/job/docker-agent/view/change-requests/job/PR-458/1/

With an additional Windows 2022 image in #441: https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-441/96/

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
