### PR TITLE
chore: disable `failFast`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
 
     stages {
         stage('docker-agent') {
-            failFast true
             matrix {
                 axes {
                     axis {


### PR DESCRIPTION
Revert #446, not useful in insight.
