### PR TITLE
chore(updatecli) track docker-bake variables with the native HCL resource instead of file

### DIFF
--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -59,13 +59,10 @@ targets:
     scmid: default
   updateDockerBake:
     name: "Update the value of the base image (ARG ALPINE_TAG) in the docker-bake.hcl"
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"ALPINE_FULL_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"ALPINE_FULL_TAG"${2}{${3}${4}${5}default${6}= "{{ source "latestVersion" }}"
+      path: variable.ALPINE_FULL_TAG.default
     scmid: default
 actions:
   default:

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -90,13 +90,10 @@ conditions:
 targets:
   setJDK11VersionDockerBake:
     name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"JAVA11_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"JAVA11_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+      path: variable.JAVA11_VERSION.default
     scmid: default
   setJDK11VersionWindowsNanoserver:
     name: "Bump JDK11 version on Windows Nanoserver image"

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -90,13 +90,10 @@ conditions:
 targets:
   setJDK17VersionDockerBake:
     name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"JAVA17_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"JAVA17_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+      path: variable.JAVA17_VERSION.default
     scmid: default
   setJDK17VersionAlpine:
     name: "Bump JDK17 default ARG version on Alpine Dockerfile"

--- a/updatecli/updatecli.d/remoting.yaml
+++ b/updatecli/updatecli.d/remoting.yaml
@@ -81,13 +81,10 @@ targets:
     scmid: default
   setDockerBakeDefaultParentImage:
     name: Bump the Jenkins remoting version on the docker-bake.hcl file
-    kind: file
+    kind: hcl
     spec:
       file: docker-bake.hcl
-      matchpattern: >-
-        variable(.*)"REMOTING_VERSION"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
-      replacepattern: >-
-        variable${1}"REMOTING_VERSION"${2}{${3}${4}${5}default${6}= "{{ source "lastVersion" }}"
+      path: variable.REMOTING_VERSION.default
     scmid: default
   setLinuxBuildShRemotingVersion:
     name: Bump the Jenkins remoting version on the linux build.sh file


### PR DESCRIPTION
Since [0.55.0](https://github.com/updatecli/updatecli/releases/tag/v0.55.0), updatecli has a [native HCL resource](https://www.updatecli.io/docs/plugins/resource/hcl/).

This PR updates the manifest to replace the tedious "file resource with matchpattern regex" in favor of the native HCL.