### PR TITLE
Add preview images for jdk21

### DIFF
--- a/alpine/21/Dockerfile
+++ b/alpine/21/Dockerfile
@@ -1,0 +1,93 @@
+ARG ALPINE_TAG=3.18.3
+FROM alpine:"${ALPINE_TAG}" AS jre-build
+ARG JAVA_VERSION
+ARG TARGETPLATFORM
+
+# hadolint ignore=DL4006
+RUN apk add --no-cache jq wget \
+  && BUILD_NUMBER=$(echo $JAVA_VERSION | cut -d'+' -f2) \
+  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | cut -d'+' -f1) \
+  && JAVA_VERSION_ENCODED=$(echo $JAVA_VERSION | jq '@uri' -jRr) \
+  && CONVERTED_ARCH=$(arch | sed 's/x86_64/x64/') \
+  && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"-ea-beta/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_alpine-linux_hotspot_ea_"${JAVA_MAJOR_VERSION}"-0-"${BUILD_NUMBER}".tar.gz -O /tmp/jdk.tar.gz \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/ \
+  && rm -f /tmp/jdk.tar.gz
+
+ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
+
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+RUN if [ "$TARGETPLATFORM" != 'linux/arm/v7' ]; then \
+    case "$(jlink --version 2>&1)" in \
+      # jlink version 11 has less features than JDK17+
+      "11."*) strip_java_debug_flags="--strip-debug" ;; \
+      *) strip_java_debug_flags="--strip-java-debug-attributes" ;; \
+    esac; \
+    jlink \
+      --add-modules ALL-MODULE-PATH \
+      "$strip_java_debug_flags" \
+      --no-man-pages \
+      --no-header-files \
+      --compress=zip-6 \
+      --output /javaruntime; \
+  else \
+    cp -r /opt/jdk-${JAVA_VERSION} /javaruntime; \
+  fi
+
+FROM alpine:"${ALPINE_TAG}" AS build
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+RUN addgroup -g "${gid}" "${group}" \
+  && adduser -h /home/"${user}" -u "${uid}" -G "${group}" -D "${user}"
+
+ARG AGENT_WORKDIR=/home/"${user}"/agent
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+ENV TZ=Etc/UTC
+
+## Always use the latest Alpine packages: no need for versions
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+      curl \
+      bash \
+      git \
+      git-lfs \
+      musl-locales \
+      openssh-client \
+      openssl \
+      procps \
+      tzdata \
+      tzdata-utils \
+    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
+
+ARG VERSION=3148.v532a_7e715ee3
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=jre-build /javaruntime "$JAVA_HOME"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+USER "${user}"
+ENV AGENT_WORKDIR="${AGENT_WORKDIR}"
+RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
+
+VOLUME /home/"${user}"/.jenkins
+VOLUME "${AGENT_WORKDIR}"
+WORKDIR /home/"${user}"
+ENV user=${user}
+LABEL \
+    org.opencontainers.image.vendor="Jenkins project" \
+    org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \
+    org.opencontainers.image.description="This is a base image, which provides the Jenkins agent executable (agent.jar)" \
+    org.opencontainers.image.version="${VERSION}" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
+    org.opencontainers.image.licenses="MIT"

--- a/debian/21/Dockerfile
+++ b/debian/21/Dockerfile
@@ -1,0 +1,86 @@
+ARG BOOKWORM_TAG=20230725
+FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
+ARG JAVA_VERSION
+ARG TARGETPLATFORM
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -x; apt-get update \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    jq \
+    wget \
+  && BUILD_NUMBER=$(echo $JAVA_VERSION | cut -d'+' -f2) \
+  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | cut -d'+' -f1) \
+  && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | jq "@uri" -jRr) \
+  && CONVERTED_ARCH=$(arch | sed 's/x86_64/x64/') \
+  && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"-ea-beta/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_ea_"${JAVA_MAJOR_VERSION}"-0-"${BUILD_NUMBER}".tar.gz -O /tmp/jdk.tar.gz \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/ \
+  && rm -f /tmp/jdk.tar.gz
+
+ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
+
+RUN jlink \
+  --add-modules ALL-MODULE-PATH \
+  --no-man-pages \
+  --compress=zip-6 \
+  --output /javaruntime
+
+
+FROM debian:bullseye-20230814 AS build
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+RUN groupadd -g "${gid}" "${group}" \
+  && useradd -l -c "Jenkins user" -d /home/"${user}" -u "${uid}" -g "${gid}" -m "${user}"
+
+ARG AGENT_WORKDIR=/home/"${user}"/agent
+ENV TZ=Etc/UTC
+
+## Always use the latest Debian packages: no need for versions
+# hadolint ignore=DL3008
+RUN apt-get update \
+  && apt-get --yes --no-install-recommends install \
+    ca-certificates \
+    curl \
+    fontconfig \
+    git \
+    git-lfs \
+    less \
+    netbase \
+    openssh-client \
+    patch \
+    tzdata \
+  && apt-get clean \
+  && rm -rf /tmp/* /var/cache/* /usr/share/doc/* /usr/share/man/* /var/lib/apt/lists/*
+
+ARG VERSION=3148.v532a_7e715ee3
+ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
+RUN chmod 0644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+
+ENV LANG C.UTF-8
+
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=jre-build /javaruntime "$JAVA_HOME"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+USER "${user}"
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/${user}/.jenkins && mkdir -p "${AGENT_WORKDIR}"
+
+VOLUME /home/"${user}"/.jenkins
+VOLUME "${AGENT_WORKDIR}"
+WORKDIR /home/"${user}"
+ENV user=${user}
+LABEL \
+  org.opencontainers.image.vendor="Jenkins project" \
+  org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \
+  org.opencontainers.image.description="This is a base image, which provides the Jenkins agent executable (agent.jar)" \
+  org.opencontainers.image.version="${VERSION}" \
+  org.opencontainers.image.url="https://www.jenkins.io/" \
+  org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
+  org.opencontainers.image.licenses="MIT"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,9 +2,11 @@ group "linux" {
   targets = [
     "alpine_jdk11",
     "alpine_jdk17",
+    "alpine_jdk21",
     "archlinux_jdk11",
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk21",
   ]
 }
 
@@ -12,6 +14,8 @@ group "linux-arm64" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk21",
+    "alpine_jdk21",
   ]
 }
 
@@ -77,6 +81,10 @@ variable "JAVA17_VERSION" {
   default = "17.0.8.1_1"
 }
 
+variable "JAVA21_VERSION" {
+  default = "21+35"
+}
+
 target "archlinux_jdk11" {
   dockerfile = "archlinux/Dockerfile"
   context    = "."
@@ -139,6 +147,25 @@ target "alpine_jdk17" {
   platforms = ["linux/amd64"]
 }
 
+target "alpine_jdk21" {
+  dockerfile = "alpine/21/Dockerfile"
+  context    = "."
+  args = {
+    ALPINE_TAG   = ALPINE_FULL_TAG
+    JAVA_VERSION = JAVA21_VERSION
+    VERSION      = REMOTING_VERSION
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk21-preview" : "",
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine${ALPINE_SHORT_TAG}-jdk21-preview" : "",
+    "${REGISTRY}/${JENKINS_REPO}:alpine-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:alpine${ALPINE_SHORT_TAG}-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-alpine${ALPINE_SHORT_TAG}-jdk21-preview",
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
 target "debian_jdk11" {
   dockerfile = "debian/Dockerfile"
   context    = "."
@@ -173,4 +200,22 @@ target "debian_jdk17" {
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk17",
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le"]
+}
+
+
+target "debian_jdk21" {
+  dockerfile = "debian/21/Dockerfile"
+  context    = "."
+  args = {
+    JAVA_VERSION = JAVA21_VERSION
+    VERSION      = REMOTING_VERSION,
+  }
+  tags = [
+    equal(ON_TAG, "true") ? "${REGISTRY}/${JENKINS_REPO}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk21-preview" : "",
+    "${REGISTRY}/${JENKINS_REPO}:bullseye-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk21-preview",
+    "${REGISTRY}/${JENKINS_REPO}:latest-jdk21-preview",
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
Add jdk21 preview images

This is something that's been discussed here https://github.com/jenkinsci/docker-inbound-agent/issues/395 in an effort to have alpine based arm64 images for the inbound agent.

### Testing done

Built locally

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

