### PR TITLE
chore(updatecli) fixup of #459 for JDK11 and JDK11 manifests

### DIFF
--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -95,19 +95,12 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA11_VERSION.default
     scmid: default
-  setJDK11VersionWindowsNanoserver:
+  setJDK11VersionWindows:
     name: "Bump JDK11 version on Windows Nanoserver image"
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: $.services.jdk11-nanoserver.build.args.JAVA_VERSION
-    scmid: default
-  setJDK11VersionWindowsServer:
-    name: "Bump JDK11 version on Windows Server image"
-    kind: yaml
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk11-windowsservercore.build.args.JAVA_VERSION
+      key: $.services.jdk11.build.args.JAVA_VERSION
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -113,19 +113,12 @@ targets:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-  setJDK17VersionWindowsNanoserver:
+  setJDK17VersionWindows:
     name: "Bump JDK17 version on Windows Nanoserver image"
     kind: yaml
     spec:
       file: build-windows.yaml
-      key: $.services.jdk17-nanoserver.build.args.JAVA_VERSION
-    scmid: default
-  setJDK17VersionWindowsServer:
-    name: "Bump JDK17 version on Windows Server image"
-    kind: yaml
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk17-windowsservercore.build.args.JAVA_VERSION
+      key: $.services.jdk17.build.args.JAVA_VERSION
     scmid: default
 
 actions:


### PR DESCRIPTION
fixup of #459 which changes the internal structure of the `build-windows.yaml`, breaking the updatecli builds.

Fixes #490 