### PR TITLE
feat(dependencies): Tracks JDK21 early access releases.

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This script checks that the provided JDK version has all the required binaries available for downloads
+# as sometimes, the tag for adoptium is published immeidatly while binaries are published later.
+##
+# The source of truth is the ERB template stored at the location dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+# It lists all the installations used as "Jenkins Tools" by the Jenkins controllers of the infrastructure
+##
+set -eu -o pipefail
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+
+function get_jdk_download_url() {
+  jdk_version="${1}"
+  platform="${2}"
+  case "${jdk_version}" in
+    8*)
+      ## JDK8 does not have the carret ('-') in their archive names
+      echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${jdk_version}/OpenJDK8U-jdk_${platform}_hotspot_${jdk_version//-}";
+      return 0;;
+    11*)
+      ## JDK11 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${jdk_version}/OpenJDK11U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    17*)
+      ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    19*)
+      ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    21*)
+      # JDK version (21+35-ea-beta)
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
+      urlEncodedJDKVersion="${jdk_version//+/%2B}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${urlEncodedJDKVersion}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-$(echo ${jdk_version} | cut -d '+' -f 2 | cut -d '-' -f 1)"
+      return 0;;
+    *)
+      echo "ERROR: unsupported JDK version (${jdk_version}).";
+      exit 1;;
+  esac
+}
+
+case "${1}" in
+  8u*)
+    # No s390x support for JDK8: $platforms is kept as default
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+  11.*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  17.*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  19.*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  21*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  *)
+    echo "ERROR: unsupported JDK version (${1}).";
+    exit 1;;
+esac
+
+for platform in "${platforms[@]}"
+do
+  url_to_check="$(get_jdk_download_url "${1}" "${platform}")"
+  if [[ "${platform}" == *windows* ]]
+  then
+    url_to_check+=".zip"
+  else
+    url_to_check+=".tar.gz"
+  fi
+  >&2 curl --connect-timeout 5 --location --head --fail --silent "${url_to_check}" || { echo "ERROR: the following URL is NOT available: ${url_to_check}."; exit 1; }
+done
+
+echo "OK: all JDK URL for version=${1} are available."

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -1,0 +1,60 @@
+---
+name: Bump JDK21 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+  temurin21-binaries:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "adoptium"
+      repository: "temurin21-binaries"
+      token: '{{ requiredEnv .github.token }}'
+      branch: "main"
+
+sources:
+  getLatestJDK21EAVersion:
+    name: Get the latest Adoptium JDK21 version
+    kind: gittag
+    scmid: temurin21-binaries
+    spec:
+      versionfilter:
+        kind: regex
+        pattern: ".*-ea-.*"
+    transformers:
+      - trimprefix: "jdk-"
+      - trimsuffix: "-ea-beta"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK21Version:
+    name: "Bump JDK21 version for Linux images in the docker-bake.hcl file"
+    kind: hcl
+    spec:
+      file: docker-bake.hcl
+      path: variable.JAVA21_VERSION.default
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK21 version (Jenkins default tools) to {{ source "getLatestJDK21EAVersion" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump JDK21 version (Jenkins tools) on all controllers
+name: Bump JDK21 version for all Linux images
 
 scms:
   default:
@@ -54,7 +54,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK21 version (Jenkins default tools) to {{ source "getLatestJDK21EAVersion" }}
+    title: Bump JDK21 version to {{ source "getLatestJDK21EAVersion" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
As we haven't seen "regular" Temurin JDK21 releases yet, I propose to track the early access versions, in case we receive another one before the official JDK21 release. This should be easy to modify once we move out of the early access mode. This follows PR #492 and issue https://github.com/jenkinsci/docker-inbound-agent/issues/395.

I have added an `updatecli `file to track the JDK21 version, as well as a shell file (borrowed from one of the infra repositories and slightly modified, thanks @smerle33) to help us ensure that the crafted URL is correct.

While not strictly necessary, it's a nice addition in my opinion. If we ever change our minds regarding the way we build the images, transitioning from Temurin's own images to only their JDK binaries, this could prove to be helpful in the future.

### Testing done

```bash
 updatecli apply --config ./updatecli/updatecli.d/jdk21.yaml --values ./updatecli/values.github-action.yaml --debug


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/jdk21.yaml"
DEBUG: stage: git-clone

DEBUG: stage: git-clone

DEBUG: cloning git repository: https://github.com/jenkinsci/docker-agent.git in /tmp/updatecli/github/jenkinsci/docker-agent

SCM repository retrieved: 2
DEBUG: cloning git repository: https://github.com/adoptium/temurin21-binaries.git in /tmp/updatecli/github/adoptium/temurin21-binaries
DEBUG:
DEBUG:
DEBUG: fetching remote branches
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec", based on "main" to directory "/tmp/updatecli/github/adoptium/temurin21-binaries"
DEBUG: fetching remote branches
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec", based on "master" to directory "/tmp/updatecli/github/jenkinsci/docker-agent"
DEBUG:
DEBUG:
DEBUG: No remote name "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec"
DEBUG: No remote name "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec"


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#########################################################
# BUMP JDK21 VERSION FOR ALL LINUX IMAGES #
#########################################################


SOURCES
=======

getLatestJDK21EAVersion
-----------------------
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec", based on "main" to directory "/tmp/updatecli/github/adoptium/temurin21-binaries"
DEBUG:
DEBUG: No remote name "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec"
Searching for version matching pattern ".*-ea-.*"
✔ Git tag "jdk-21+35-ea-beta" found matching pattern ".*-ea-.*" of kind "regex"
DEBUG: empty changelog found for the source


CONDITIONS:
===========

checkIfReleaseIsAvailable
-------------------------
DEBUG: No shell success criteria defined, updatecli fallbacks to historical workflow
DEBUG:  command: /bin/sh /tmp/updatecli/bin/fb063aef0b0daf919e4f1e59666db351f3dc21a3451d2f19630dc86e730839e3.sh
DEBUG: Environment variables
DEBUG:  * UPDATECLI_PIPELINE_STAGE=condition
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/fb063aef0b0daf919e4f1e59666db351f3dc21a3451d2f19630dc86e730839e3.sh" ran successfully with the following output:
----
OK: all JDK URL for version=21+35 are available.
----

✔ shell condition of type "console/output", passing


TARGETS
========

setJDK21Version
---------------
DEBUG: stage: git-checkout

DEBUG: checkout branch "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec", based on "master" to directory "/tmp/updatecli/github/jenkinsci/docker-agent"
DEBUG:
DEBUG: No remote name "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec"
DEBUG: /tmp/updatecli/github/jenkinsci/docker-agent
DEBUG: Relative path detected: changing from "docker-bake.hcl" to absolute path from SCM: "/tmp/updatecli/github/jenkinsci/docker-agent/docker-bake.hcl"
✔ - path "variable.JAVA21_VERSION.default" already set to "21+35", from file "docker-bake.hcl",
DEBUG: Checking if local changes have been done that should be published
DEBUG: no changes detected between branches "master" and "updatecli_7428af4139f81c23b31d56f1943c6cfe0800a4d2f126ede5a61d677a0adcc7ec"


ACTIONS
========


=============================

REPORTS:



✔ Bump JDK21 version (Jenkins tools) on all controllers:
        Source:
                ✔ [getLatestJDK21EAVersion] Get the latest Adoptium JDK21 version
        Condition:
                ✔ [checkIfReleaseIsAvailable]
        Target:
                ✔ [setJDK21Version] Bump JDK21 version for Linux images in the docker-bake.hcl file


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
``` 

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
