### PR TITLE
feat(platforms): Adds ppc64le and s390x archs for JDK21.

### DIFF
--- a/debian/21/Dockerfile
+++ b/debian/21/Dockerfile
@@ -1,4 +1,4 @@
-ARG BOOKWORM_TAG=20230725
+ARG BOOKWORM_TAG=20230904
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
 ARG JAVA_VERSION
 ARG TARGETPLATFORM
@@ -13,7 +13,7 @@ RUN set -x; apt-get update \
   && BUILD_NUMBER=$(echo $JAVA_VERSION | cut -d'+' -f2) \
   && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | cut -d'+' -f1) \
   && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | jq "@uri" -jRr) \
-  && CONVERTED_ARCH=$(arch | sed 's/x86_64/x64/') \
+  && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"-ea-beta/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_ea_"${JAVA_MAJOR_VERSION}"-0-"${BUILD_NUMBER}".tar.gz -O /tmp/jdk.tar.gz \
   && tar -xzf /tmp/jdk.tar.gz -C /opt/ \
   && rm -f /tmp/jdk.tar.gz
@@ -27,7 +27,7 @@ RUN jlink \
   --output /javaruntime
 
 
-FROM debian:bullseye-20230814 AS build
+FROM debian:bookworm-"${BOOKWORM_TAG}" AS build
 
 ARG user=jenkins
 ARG group=jenkins

--- a/debian/21/Dockerfile
+++ b/debian/21/Dockerfile
@@ -20,12 +20,17 @@ RUN set -x; apt-get update \
 
 ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
 
-RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --no-man-pages \
-  --compress=zip-6 \
-  --output /javaruntime
-
+RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
+      jlink \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --compress=zip-6 \
+        --output /javaruntime; \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
+    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
+    else  \
+      cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+    fi
 
 FROM debian:bookworm-"${BOOKWORM_TAG}" AS build
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -217,5 +217,5 @@ target "debian_jdk21" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk21-preview",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk21-preview",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/arm/v7"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -217,5 +217,5 @@ target "debian_jdk21" {
     "${REGISTRY}/${JENKINS_REPO}:latest-bullseye-jdk21-preview",
     "${REGISTRY}/${JENKINS_REPO}:latest-jdk21-preview",
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }


### PR DESCRIPTION
After discussing with @ksalerno99 yesterday during the [Platform SIG meeting](https://www.jenkins.io/sigs/platform/), I considered that adding support for a few platforms for JDK21 would be beneficial.

I then propose to add `"linux/ppc64le"`, `"linux/armv/v7"`  and `"linux/s390x"` as new target platforms for our JDK21 preview images.

### Testing done

`docker buildx bake --file docker-bake.hcl debian_jdk21`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
