### PR TITLE
fix(windows) bump `git-lfs` to 3.4.0 and fix its installation

### DIFF
--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -73,13 +73,13 @@ Describe "[$global:AGENT_IMAGE] image has correct applications in the PATH" {
     }
 
     It 'has git-lfs (and thus git) installed' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`$global:GITLFSVERSION = git lfs version 2>&1 ; Write-Host `$global:GITLFSVERSION`""
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs version`""
         $exitCode | Should -Be 0
-        # $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
-        $r = [regex] "^git-lfs/`"(?<gitlfsversion>\d+)"
-        $m = $r.Match($stdout)
-        $m | Should -Not -Be $null
-        $m.Groups['gitlfsversion'].ToString() | Should -Be $global:GITLFSVERSION
+        $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
+        # $r = [regex] "^git-lfs/`"(?<gitlfsversion>\d+)"
+        # $m = $r.Match($stdout)
+        # $m | Should -Not -Be $null
+        # $m.Groups['gitlfsversion'].ToString() | Should -Be $global:GITLFSVERSION
     }
 
     AfterAll {

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -76,10 +76,6 @@ Describe "[$global:AGENT_IMAGE] image has correct applications in the PATH" {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs version`""
         $exitCode | Should -Be 0
         $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
-        # $r = [regex] "^git-lfs/`"(?<gitlfsversion>\d+)"
-        # $m = $r.Match($stdout)
-        # $m | Should -Not -Be $null
-        # $m.Groups['gitlfsversion'].ToString() | Should -Be $global:GITLFSVERSION
     }
 
     AfterAll {

--- a/updatecli/updatecli.d/git-lfs-windows.yaml
+++ b/updatecli/updatecli.d/git-lfs-windows.yaml
@@ -45,6 +45,17 @@ targets:
         keyword: ARG
         matcher: GIT_LFS_VERSION
     scmid: default
+  setGitLfsVersionTests:
+    name: Update the `git-lfs` Windows version for Windows Core Server
+    kind: file
+    spec:
+      file: tests/agent.Tests.ps1
+      matchpattern: >
+        global:GIT_LFS_VERSION = '(.*)'$
+      replacepattern: >
+        global:GIT_LFS_VERSION = '{{ source "lastVersion" }}'
+    scmid: default
+    
 
 actions:
   default:

--- a/updatecli/updatecli.d/git-lfs-windows.yaml
+++ b/updatecli/updatecli.d/git-lfs-windows.yaml
@@ -46,7 +46,7 @@ targets:
         matcher: GIT_LFS_VERSION
     scmid: default
   setGitLfsVersionTests:
-    name: Update the `git-lfs` Windows version for Windows Core Server
+    name: Update the `git-lfs` Windows version in tests
     kind: file
     spec:
       file: tests/agent.Tests.ps1

--- a/updatecli/updatecli.d/git-lfs-windows.yaml
+++ b/updatecli/updatecli.d/git-lfs-windows.yaml
@@ -55,7 +55,6 @@ targets:
       replacepattern: >
         global:GIT_LFS_VERSION = '{{ source "lastVersion" }}'
     scmid: default
-    
 
 actions:
   default:

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -55,7 +55,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.1.4
+ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;C:\mingit\cmd"
+
+ARG GIT_LFS_VERSION=3.4.0
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `
@@ -67,7 +69,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
 ENV ProgramFiles="C:\Program Files" `
     WindowsPATH="C:\Windows\system32;C:\Windows" `
     JAVA_HOME="${JAVA_HOME}"
-ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;C:\mingit\cmd"
 
 ARG user=jenkins
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -66,8 +66,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
-    $gitLfsFolder = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
-    Move-Item -Path "${gitLfsFolder}\git-lfs.exe" -Destination 'c:\mingit\mingw64\bin\' ; `
+    $gitLfsFolder = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION ; `
+    Move-Item -Path "${gitLfsFolder}\git-lfs.exe" -Destination c:\mingit\mingw64\bin\ ; `
     Remove-Item -Path $gitLfsFolder -Recurse -Force ; `
     Remove-Item GitLfs.zip -Force ; `
     & c:\mingit\mingw64\bin\git-lfs.exe install

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -68,7 +68,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
     $gitLfsFolder = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
     Move-Item -Path "${gitLfsFolder}\git-lfs.exe" -Destination 'c:\mingit\mingw64\bin\' ; `
-    Remove-Item -Path $gitLfsFolder -Recurse -Force
+    Remove-Item -Path $gitLfsFolder -Recurse -Force ; `
     Remove-Item GitLfs.zip -Force ; `
     & c:\mingit\mingw64\bin\git-lfs.exe install
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -55,6 +55,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
+ENV ProgramFiles="C:\Program Files" `
+    WindowsPATH="C:\Windows\system32;C:\Windows" `
+    JAVA_HOME="${JAVA_HOME}"
 ENV PATH="${WindowsPATH};${ProgramFiles}\PowerShell;${JAVA_HOME}\bin;C:\mingit\cmd"
 
 ARG GIT_LFS_VERSION=3.4.0
@@ -64,11 +67,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
     Remove-Item GitLfs.zip -Force ; `
-    & C:\mingit\cmd\git.exe lfs install
-
-ENV ProgramFiles="C:\Program Files" `
-    WindowsPATH="C:\Windows\system32;C:\Windows" `
-    JAVA_HOME="${JAVA_HOME}"
+    & c:\mingit\mingw64\bin\git-lfs.exe install
 
 ARG user=jenkins
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -67,7 +67,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
     Remove-Item GitLfs.zip -Force ; `
-    & c:\mingit\mingw64\bin\git-lfs-3.4.0\git-lfs.exe install
+    $gitLfsPath = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
+    & ${gitLfsPath}\git-lfs.exe install
 
 ARG user=jenkins
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -66,9 +66,11 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
-    Remove-Item GitLfs.zip -Force ; `
     $gitLfsPath = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
-    & ${gitLfsPath}\git-lfs.exe install
+    Move-Item -Path "${gitLfsPath}\git-lfs.exe" -Destination 'c:\mingit\mingw64\bin\' ; `
+    Remove-Item -Path $gitLfsPath -Recurse -Force
+    Remove-Item GitLfs.zip -Force ; `
+    & c:\mingit\mingw64\bin\git-lfs.exe install
 
 ARG user=jenkins
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -67,7 +67,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
     Remove-Item GitLfs.zip -Force ; `
-    & c:\mingit\mingw64\bin\git-lfs.exe install
+    & c:\mingit\mingw64\bin\git-lfs-3.4.0\git-lfs.exe install
 
 ARG user=jenkins
 

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -66,9 +66,9 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
-    $gitLfsPath = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
-    Move-Item -Path "${gitLfsPath}\git-lfs.exe" -Destination 'c:\mingit\mingw64\bin\' ; `
-    Remove-Item -Path $gitLfsPath -Recurse -Force
+    $gitLfsFolder = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION) ; `
+    Move-Item -Path "${gitLfsFolder}\git-lfs.exe" -Destination 'c:\mingit\mingw64\bin\' ; `
+    Remove-Item -Path $gitLfsFolder -Recurse -Force
     Remove-Item GitLfs.zip -Force ; `
     & c:\mingit\mingw64\bin\git-lfs.exe install
 

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -47,7 +47,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
-ARG GIT_LFS_VERSION=3.1.4
+ARG GIT_LFS_VERSION=3.4.0
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -47,18 +47,22 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive mingit.zip -DestinationPath c:\mingit ; `
     Remove-Item mingit.zip -Force
 
+# Add git and java in PATH
+RUN $CurrentPath = (Get-Itemproperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path).Path ; `
+    $NewPath = $CurrentPath + $(';{0}\bin;C:\mingit\cmd' -f $env:JAVA_HOME) ; `
+    Set-ItemProperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path -Value $NewPath
+
 ARG GIT_LFS_VERSION=3.4.0
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $url = $('https://github.com/git-lfs/git-lfs/releases/download/v{0}/git-lfs-windows-amd64-v{0}.zip' -f $env:GIT_LFS_VERSION) ; `
     Write-Host "Retrieving $url..." ; `
     Invoke-WebRequest $url -OutFile 'GitLfs.zip' -UseBasicParsing ; `
     Expand-Archive GitLfs.zip -DestinationPath c:\mingit\mingw64\bin ; `
+    $gitLfsFolder = 'c:\mingit\mingw64\bin\git-lfs-{0}' -f $env:GIT_LFS_VERSION ; `
+    Move-Item -Path "${gitLfsFolder}\git-lfs.exe" -Destination c:\mingit\mingw64\bin\ ; `
+    Remove-Item -Path $gitLfsFolder -Recurse -Force ; `
     Remove-Item GitLfs.zip -Force ; `
-    & C:\mingit\cmd\git.exe lfs install ; `
-    $CurrentPath = (Get-Itemproperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path).Path ; `
-    # Add git and java in PATH
-    $NewPath = $CurrentPath + $(';{0}\bin;C:\mingit\cmd' -f $env:JAVA_HOME) ; `
-    Set-ItemProperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path -Value $NewPath
+    & c:\mingit\mingw64\bin\git-lfs.exe install
 
 ARG user=jenkins
 


### PR DESCRIPTION
This PR fixes the `git: 'lfs' is not a git command.` error noticed in https://github.com/jenkinsci/docker-agent/pull/502#issuecomment-1717648730 when using the version 3.4.0 of git-lfs by adding git to the `PATH` earlier then using git-lfs.exe installer instead of `git.exe lfs install`.

It also adds a test ensuring git-lfs (and thus git) is correctly installed.

Supersedes and closes #502

### Testing done

https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-503/11/

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
