### PR TITLE
test: check if `git-lfs` is correctly installed on Windows images

### DIFF
--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -23,6 +23,8 @@ if($global:WINDOWSFLAVOR -eq 'nanoserver') {
     $global:CONTAINERSHELL = "pwsh.exe"
 }
 
+$global:GITLFSVERSION = '3.1.4'
+
 Cleanup($global:CONTAINERNAME)
 
 Describe "[$global:AGENT_IMAGE] image is present" {
@@ -68,6 +70,12 @@ Describe "[$global:AGENT_IMAGE] image has correct applications in the PATH" {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"Get-ChildItem env:`""
         $exitCode | Should -Be 0
         $stdout.Trim() | Should -Match "user.*jenkins"
+    }
+
+    It 'has git-lfs (and thus git) installed' {
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs version`""
+        $exitCode | Should -Be 0
+        $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
     }
 
     AfterAll {

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -74,8 +74,8 @@ Describe "[$global:AGENT_IMAGE] image has correct applications in the PATH" {
 
     It 'has git-lfs (and thus git) installed' {
         $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs version`""
-        $exitCode | Should -Be 0
         $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
+        $exitCode | Should -Be 0
     }
 
     AfterAll {


### PR DESCRIPTION
Extracted from #503

Out of curiosity I opened this PR to check if git-lfs 3.1.4 was indeed installed in Windows images, it was: https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-504/2/ ✅ 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
