### PR TITLE
fix(docker): Adds "debian_jdk21" in s390x and ppc64le groups.

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,13 +22,15 @@ group "linux-arm64" {
 group "linux-arm32" {
   targets = [
     "debian_jdk11",
-    "debian_jdk17"
+    "debian_jdk17",
+    "debian_jdk21"
   ]
 }
 
 group "linux-s390x" {
   targets = [
     "debian_jdk11",
+    "debian_jdk21"
   ]
 }
 
@@ -36,6 +38,7 @@ group "linux-ppc64le" {
   targets = [
     "debian_jdk11",
     "debian_jdk17",
+    "debian_jdk21"
   ]
 }
 


### PR DESCRIPTION
[Today](#498), we added new architectures for `debian_jdk21`, but I forgot to add `debian_jdk21` to the existing groups (arm32, ppc64le and s390x).
My bad.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
