### PR TITLE
chore(updatecli) correct regexp error to fix git-lfs manifest

### DIFF
--- a/updatecli/updatecli.d/git-lfs-windows.yaml
+++ b/updatecli/updatecli.d/git-lfs-windows.yaml
@@ -51,9 +51,9 @@ targets:
     spec:
       file: tests/agent.Tests.ps1
       matchpattern: >
-        global:GIT_LFS_VERSION = '(.*)'$
+        global:GITLFSVERSION =(.*)
       replacepattern: >
-        global:GIT_LFS_VERSION = '{{ source "lastVersion" }}'
+        global:GITLFSVERSION = '{{ source "lastVersion" }}'
     scmid: default
 
 actions:


### PR DESCRIPTION
This PR is an `updatecli` fixup of #503 for the `git-lfs` manifest