### PR TITLE
Replace bullseye with bookworm in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ docker run -i --rm --name agent1 --init -v agent1-workdir:C:/Users/jenkins/Work 
 The image has several supported configurations, which can be accessed via the following tags:
 
 * Linux Images:
-  * `latest` (`jdk11`, `bullseye-jdk11`, `latest-bullseye-jdk11`, `latest-jdk11`): Latest version with the newest remoting and Java 11 (based on `debian:bullseye-${builddate}`)
+  * `latest` (`jdk11`, `bookworm-jdk11`, `latest-bookworm-jdk11`, `latest-jdk11`): Latest version with the newest remoting and Java 11 (based on `debian:bookworm-${builddate}`)
   * `alpine` (`alpine-jdk11`, `latest-alpine`, `latest-alpine-jdk11`): Small image based on Alpine Linux (based on `alpine:${version}`)
   * `archlinux` (`latest-archlinux`, `archlinux-jdk11`, `latest-archlinux-jdk11`): Image based on Arch Linux with JDK11 (based on `archlinux:latest`)
-  * `bullseye-jdk17` (`jdk17`, `latest-bullseye-jdk17`, `latest-jdk17`): JDK17 version with the newest remoting (based on `debian:bullseye-${builddate}`)
+  * `bookworm-jdk17` (`jdk17`, `latest-bookworm-jdk17`, `latest-jdk17`): JDK17 version with the newest remoting (based on `debian:bookworm-${builddate}`)
 
 From version 4.11.2, the alpine images are tagged using the alpine OS version as well (i.e. `alpine` ==> `alpine3.16`, `alpine-jdk11` ==> `alpine3.16-jdk11`).
 


### PR DESCRIPTION
## Replace bullseye with bookworm in docs

The documentation was mentioning bullseye while the container images we build are limited to bookworm.

Related to:

* #499
* #516

### Testing done

Confirmed that all the tags referenced in the updated documentation exist on Dockerhub and report the correct operating system when they are executed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
