### PR TITLE
chore: print the docker-bake targets for linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,7 @@ ORGANIZATION=${DOCKERHUB_ORGANISATION:-jenkins}
 remoting_version=${REMOTING_VERSION:-${remoting_version}}
 
 if [[ "${target}" = "build" ]] ; then
+  make show
   make build
   exit_result=$?
   exit_if_error
@@ -77,6 +78,7 @@ if [[ "${target}" = "publish" ]] ; then
     export ON_TAG=true
     export BUILD_NUMBER=$build_number
   fi
+  make show
   docker buildx bake --push --file docker-bake.hcl linux
   exit_result=$?
 fi


### PR DESCRIPTION
Similar what has been added to the Windows logs with https://github.com/jenkinsci/docker-agent/pull/461, this PR shows the output of `docker buildx -f docker-bake.hcl --print linux` before building or publishing Linux images (but not before testing, should already been shown previously), listing all their info.

<details><summary>Example of output:</summary>

```json
{
   "group": {
     "default": {
       "targets": [
         "linux"
       ]
     },
     "linux": {
       "targets": [
         "alpine_jdk11",
         "alpine_jdk17",
         "alpine_jdk21",
         "archlinux_jdk11",
         "debian_jdk11",
         "debian_jdk17",
         "debian_jdk21"
       ]
     }
   },
   "target": {
     "alpine_jdk11": {
       "context": ".",
       "dockerfile": "alpine/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.18.4",
         "JAVA_VERSION": "11.0.20.1_1",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:alpine-jdk11",
         "docker.io/jenkins/agent:alpine3.18-jdk11",
         "docker.io/jenkins/agent:latest-alpine-jdk11",
         "docker.io/jenkins/agent:latest-alpine3.18-jdk11"
       ],
       "platforms": [
         "linux/amd64"
       ],
       "output": [
         "type=docker"
       ]
     },
     "alpine_jdk17": {
       "context": ".",
       "dockerfile": "alpine/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.18.4",
         "JAVA_VERSION": "17.0.8.1_1",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:alpine",
         "docker.io/jenkins/agent:alpine3.18",
         "docker.io/jenkins/agent:alpine-jdk17",
         "docker.io/jenkins/agent:alpine3.18-jdk17",
         "docker.io/jenkins/agent:latest-alpine",
         "docker.io/jenkins/agent:latest-alpine3.18",
         "docker.io/jenkins/agent:latest-alpine-jdk17",
         "docker.io/jenkins/agent:latest-alpine3.18-jdk17"
       ],
       "platforms": [
         "linux/amd64"
       ],
       "output": [
         "type=docker"
       ]
     },
     "alpine_jdk21": {
       "context": ".",
       "dockerfile": "alpine/21/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.18.4",
         "JAVA_VERSION": "21+35",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:alpine-jdk21-preview",
         "docker.io/jenkins/agent:alpine3.18-jdk21-preview",
         "docker.io/jenkins/agent:latest-alpine-jdk21-preview",
         "docker.io/jenkins/agent:latest-alpine3.18-jdk21-preview"
       ],
       "platforms": [
         "linux/amd64",
         "linux/arm64"
       ],
       "output": [
         "type=docker"
       ]
     },
     "archlinux_jdk11": {
       "context": ".",
       "dockerfile": "archlinux/Dockerfile",
       "args": {
         "JAVA_VERSION": "11.0.20.1_1",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:archlinux",
         "docker.io/jenkins/agent:latest-archlinux",
         "docker.io/jenkins/agent:archlinux-jdk11",
         "docker.io/jenkins/agent:latest-archlinux-jdk11"
       ],
       "platforms": [
         "linux/amd64"
       ],
       "output": [
         "type=docker"
       ]
     },
     "debian_jdk11": {
       "context": ".",
       "dockerfile": "debian/Dockerfile",
       "args": {
         "DEBIAN_RELEASE": "bookworm-20230904",
         "JAVA_VERSION": "11.0.20.1_1",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:bookworm-jdk11",
         "docker.io/jenkins/agent:jdk11",
         "docker.io/jenkins/agent:latest-bookworm-jdk11",
         "docker.io/jenkins/agent:latest-jdk11"
       ],
       "platforms": [
         "linux/amd64",
         "linux/arm64",
         "linux/arm/v7",
         "linux/s390x",
         "linux/ppc64le"
       ],
       "output": [
         "type=docker"
       ]
     },
     "debian_jdk17": {
       "context": ".",
       "dockerfile": "debian/Dockerfile",
       "args": {
         "DEBIAN_RELEASE": "bookworm-20230904",
         "JAVA_VERSION": "17.0.8.1_1",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:bookworm-jdk17",
         "docker.io/jenkins/agent:jdk17",
         "docker.io/jenkins/agent:latest",
         "docker.io/jenkins/agent:latest-bookworm",
         "docker.io/jenkins/agent:latest-bookworm-jdk17",
         "docker.io/jenkins/agent:latest-jdk17"
       ],
       "platforms": [
         "linux/amd64",
         "linux/arm64",
         "linux/arm/v7",
         "linux/ppc64le"
       ],
       "output": [
         "type=docker"
       ]
     },
     "debian_jdk21": {
       "context": ".",
       "dockerfile": "debian/21/Dockerfile",
       "args": {
         "DEBIAN_RELEASE": "bookworm-20230904",
         "JAVA_VERSION": "21+35",
         "VERSION": "3160.vd76b_9ddd10cc"
       },
       "tags": [
         "docker.io/jenkins/agent:bookworm-jdk21-preview",
         "docker.io/jenkins/agent:jdk21-preview",
         "docker.io/jenkins/agent:latest-bookworm-jdk21-preview",
         "docker.io/jenkins/agent:latest-jdk21-preview"
       ],
       "platforms": [
         "linux/amd64",
         "linux/arm64",
         "linux/ppc64le",
         "linux/s390x",
         "linux/arm/v7"
       ],
       "output": [
         "type=docker"
       ]
     }
   }
 }
```

</details>

### Testing done

https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-530/5/
- `./build.sh` with output: https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-530/4/execution/node/114/log/
- `./build.sh test` without output (already shown with `./build.sh` above): https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-530/4/execution/node/163/log/

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
