### PR TITLE
chore(updatecli) remove reference to a deleted file for Alpine

### DIFF
--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -57,15 +57,6 @@ targets:
         keyword: "ARG"
         matcher: "ALPINE_TAG"
     scmid: default
-  updateDockerfileJdk21:
-    name: "Update the value of the base image (ARG ALPINE_TAG) in the Dockerfile"
-    kind: dockerfile
-    spec:
-      file: alpine/21/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "ALPINE_TAG"
-    scmid: default
   updateDockerBake:
     name: "Update the value of the base image (ARG ALPINE_TAG) in the docker-bake.hcl"
     kind: hcl


### PR DESCRIPTION
Quick hotfix of #521 to correct the `updatecli` process which is failing on the `master` branch