### PR TITLE
chore(updatecli): add `jdk21-preview` manifest and adapt `check-jdk.sh` script

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -29,11 +29,18 @@ function get_jdk_download_url() {
       ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    21*)
-      # JDK version (21+35-ea-beta)
+    21*-ea-beta)
+      # JDK preview version (21+35-ea-beta, 21.0.1+12-ea-beta)
+      jdk_version="${jdk_version//-ea-beta}"
       ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
-      urlEncodedJDKVersion="${jdk_version//+/%2B}"
-      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${urlEncodedJDKVersion}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-$(echo ${jdk_version} | cut -d '+' -f 2 | cut -d '-' -f 1)"
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12-ea-beta/OpenJDK21U-jdk_x64_linux_hotspot_ea_21-0-1-12.tar.gz
+      dashJDKVersion="${jdk_version//+/-}"
+      completeDashJDKVersion="${dashJDKVersion//./-}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_${completeDashJDKVersion}"
+      return 0;;
+    21*)
+      ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";
@@ -51,8 +58,10 @@ case "${1}" in
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   19.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
-  21*+*)
+  21*+*-ea-beta)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  21*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
   *)
     echo "ERROR: unsupported JDK version (${1}).";
     exit 1;;

--- a/updatecli/updatecli.d/jdk21-preview.yaml
+++ b/updatecli/updatecli.d/jdk21-preview.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump JDK21 version for all Linux images
+name: Bump JDK21 preview version (EA) for all Linux images
 
 scms:
   default:
@@ -40,14 +40,16 @@ conditions:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+    transformers:
+      - addsuffix: "-ea-beta"
 
 targets:
-  setJDK21Version:
+  setJDK21PreviewVersionDockerBake:
     name: "Bump JDK21 version for Linux images in the docker-bake.hcl file"
     kind: hcl
     spec:
       file: docker-bake.hcl
-      path: variable.JAVA21_VERSION.default
+      path: variable.JAVA21_PREVIEW_VERSION.default
     scmid: default
 
 actions:
@@ -58,4 +60,4 @@ actions:
     spec:
       labels:
         - dependencies
-        - jdk21
+        - jdk21-preview

--- a/updatecli/updatecli.d/jdk21-preview.yaml
+++ b/updatecli/updatecli.d/jdk21-preview.yaml
@@ -23,8 +23,8 @@ scms:
       branch: "main"
 
 sources:
-  getLatestJDK21EAVersion:
-    name: Get the latest Adoptium JDK21 version
+  getLatestJDK21PreviewVersion:
+    name: Get the latest Adoptium preview (EA) JDK21 version
     kind: gittag
     scmid: temurin21-binaries
     spec:
@@ -45,7 +45,7 @@ conditions:
 
 targets:
   setJDK21PreviewVersionDockerBake:
-    name: "Bump JDK21 version for Linux images in the docker-bake.hcl file"
+    name: "Bump preview (EA) JDK21 version for Linux images in the docker-bake.hcl file"
     kind: hcl
     spec:
       file: docker-bake.hcl
@@ -56,7 +56,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK21 version to {{ source "getLatestJDK21EAVersion" }}
+    title: Bump preview (EA) JDK21 version to {{ source "getLatestJDK21PreviewVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -23,23 +23,29 @@ scms:
       branch: "main"
 
 sources:
-  getLatestJDK21EAVersion:
+  getLatestJDK21Version:
     name: Get the latest Adoptium JDK21 version
     kind: gittag
     scmid: temurin21-binaries
     spec:
       versionfilter:
         kind: regex
-        pattern: ".*-ea-.*"
+        pattern: "\\d$"
     transformers:
       - trimprefix: "jdk-"
-      - trimsuffix: "-ea-beta"
+      - replacer:
+          from: "+"
+          to: "_"
 
 conditions:
   checkIfReleaseIsAvailable:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+    transformers:
+      - replacer:
+          from: "_"
+          to: "+"
 
 targets:
   setJDK21Version:
@@ -54,7 +60,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK21 version to {{ source "getLatestJDK21EAVersion" }}
+    title: Bump JDK21 version to {{ source "getLatestJDK21Version" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
This PR is a follow-up of #521, complement of #535, similar to https://github.com/jenkinsci/docker/pull/1741

<!-- Please describe your pull request here. -->

### Testing done

https://github.com/jenkinsci/docker-agent/actions/runs/6606391106/job/17942546905?pr=536

<details><summary>Corresponding updatecli logs:</summary>

```

########################################################
# BUMP JDK21 PREVIEW VERSION (EA) FOR ALL LINUX IMAGES #
########################################################


SOURCES
=======

getLatestJDK21PreviewVersion
----------------------------
Searching for version matching pattern ".*-ea-.*"
✔ Git tag "jdk-21.0.1+12-ea-beta" found matching pattern ".*-ea-.*" of kind "regex"


CONDITIONS:
===========

checkIfReleaseIsAvailable
-------------------------
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/e178f4342f912570a17f53f2079a8f8a53445ca928f785971065f2d450977844.sh" ran successfully with the following output:
----
OK: all JDK URL for version=21.0.1+12-ea-beta are available.
----
✔ shell condition of type "console/output", passing


TARGETS
========

setJDK21PreviewVersionDockerBake
--------------------------------

**Dry Run enabled**

⚠ - path "variable.JAVA21_PREVIEW_VERSION.default" updated from "21+35" to "21.0.1+12" in file "docker-bake.hcl"


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.


###########################################
# BUMP JDK21 VERSION FOR ALL LINUX IMAGES #
###########################################


SOURCES
=======

getLatestJDK21Version
---------------------
Searching for version matching pattern "\\d$"
✔ Git tag "jdk-21+35" found matching pattern "\\d$" of kind "regex"


CONDITIONS:
===========

checkIfReleaseIsAvailable
-------------------------
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/fb063aef0b0daf919e4f1e59666db351f3dc21a3451d2f19630dc86e730839e3.sh" ran successfully with the following output:
----
OK: all JDK URL for version=21+35 are available.
----
✔ shell condition of type "console/output", passing


TARGETS
========

setJDK21Version
---------------

**Dry Run enabled**

✔ - path "variable.JAVA21_VERSION.default" already set to "21_35", from file "docker-bake.hcl", 
```

</details>

LGTM.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
