### PR TITLE
Revert "Bump JDK21 version to 21.0.2_13"

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -117,7 +117,7 @@ variable "JAVA17_VERSION" {
 }
 
 variable "JAVA21_VERSION" {
-  default = "21.0.2_13"
+  default = "21.0.1_12"
 }
 
 variable "JAVA21_PREVIEW_VERSION" {


### PR DESCRIPTION
Reverts jenkinsci/docker-agent#773 because build fails consistently on Windows after this merge