### PR TITLE
feat(JDK21) Use official Temurin build for `linux/s390x`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -56,7 +56,7 @@ group "linux-arm32" {
 group "linux-s390x" {
   targets = [
     "debian_jdk11",
-    "debian_jdk21_preview"
+    "debian_jdk21"
   ]
 }
 
@@ -294,7 +294,7 @@ target "debian_jdk21" {
     "${REGISTRY}/${orgrepo(type)}:latest-bookworm-jdk21",
     "${REGISTRY}/${orgrepo(type)}:latest-jdk21",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }
 
 target "debian_jdk21_preview" {
@@ -317,5 +317,5 @@ target "debian_jdk21_preview" {
     "${REGISTRY}/${orgrepo(type)}:latest-bookworm-jdk21-preview",
     "${REGISTRY}/${orgrepo(type)}:latest-jdk21-preview",
   ]
-  platforms = ["linux/s390x", "linux/arm/v7"]
+  platforms = ["linux/arm/v7"]
 }

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -60,10 +60,8 @@ case "${1}" in
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   19.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
-  21*+*-ea-beta)
-    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   21*+*)
-    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   *)
     echo "ERROR: unsupported JDK version (${1}).";
     exit 1;;


### PR DESCRIPTION
This is a follow-up to #772.
@MarkEWaite [noted](https://github.com/jenkinsci/docker-agent/pull/772#issuecomment-2002012356) that we should use the official build versions for the architectures that have moved out of preview.
@dduportal then noted that the only one that was left was s390x.

I'm proposing this small change to remove `s390x`'s JDK from the preview and start using the official Temurin builds.

I noticed that there was no `arm32 `defined in [check-jdk.sh](https://github.com/jenkinsci/docker-agent/blob/master/updatecli/scripts/check-jdk.sh#L32), even though it is supposed to be called by the [`jdk21-preview` manifest](https://github.com/jenkinsci/docker-agent/blob/master/updatecli/updatecli.d/jdk21-preview.yaml#L42).

I'm not sure how we got this working for `arm32 `in the first place. I'm not saying it isn't working; I just don't understand how it works. 🤷

So, I haven't removed the `arm32 `support in this PR. I will do so in another PR, but it could have some side effects for `arm32 `(or not; I'm sure you all understand how this worked for `arm32`).

Anyway, there is no new Temurin release for `arm32 `in `ea-beta` (or anything else, to be clear), so that shouldn't be an issue.
### Testing done

`make build agent_debian_jdk21_preview` and `make build agent_debian_jdk21_preview`.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue