### PR TITLE
Add `-noReconnectAfter` option support

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -37,6 +37,7 @@
 # * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins controller. When this is set,
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
+# * JENKINS_NO_RECONNECT_AFTER: Do not attempt to reconnect to the Jenkins controller after the given timeout.
 
 if [ $# -eq 1 ] && [ "${1#-}" = "$1" ] ; then
 
@@ -114,6 +115,10 @@ else
 			SECRET="-secret ${JENKINS_SECRET}" ;;
 		esac
 	fi
+
+	if [ -n "$JENKINS_NO_RECONNECT_AFTER" ]; then
+	  NO_RECONNECT_AFTER="-noReconnectAfter $JENKINS_NO_RECONNECT_AFTER"
+  fi
 	
 	if [ -n "$JENKINS_AGENT_NAME" ]; then
 		case "$@" in
@@ -126,6 +131,6 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $NO_RECONNECT_AFTER "$@"
 
 fi

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -34,7 +34,8 @@ Param(
     $Protocols = '',
     $JenkinsJavaBin = '',
     $JavaHome = $env:JAVA_HOME,
-    $JenkinsJavaOpts = ''
+    $JenkinsJavaOpts = '',
+    $NoReconnectAfter = ''
 )
 
 # Usage jenkins-agent.ps1 [options] -Url http://jenkins -Secret [SECRET] -Name [AGENT_NAME]
@@ -52,6 +53,7 @@ Param(
 # * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins controller. When this is set,
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
+# * JENKINS_NO_RECONNECT_AFTER: Do not attempt to reconnect to the Jenkins controller after the given timeout.
 
 if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
 	Invoke-Expression "$Cmd"
@@ -70,6 +72,7 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
         'DirectConnection' = 'JENKINS_DIRECT_CONNECTION';
         'InstanceIdentity' = 'JENKINS_INSTANCE_IDENTITY';
         'Protocols' = 'JENKINS_PROTOCOLS';
+        'NoReconnectAfter' = 'JENKINS_NO_RECONNECT_AFTER';
     }
 
     # this does some trickery to update the variable from the CmdletBinding
@@ -136,6 +139,10 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
 
     if(![System.String]::IsNullOrWhiteSpace($Protocols)) {
         $AgentArguments += @('-protocols', $Protocols)
+    }
+
+    if(![System.String]::IsNullOrWhiteSpace($NoReconnectAfter)) {
+        $AgentArguments += @('-noReconnectAfter', $NoReconnectAfter)
     }
 
     if(![System.String]::IsNullOrWhiteSpace($JenkinsJavaBin)) {


### PR DESCRIPTION
* [ ] Downstream of https://github.com/jenkinsci/remoting/pull/738

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
