### PR TITLE
Introduce `REMOTING_OPTS` to pass arbitrary options to remoting on startup via an environment variable

### DIFF
--- a/jenkins-agent
+++ b/jenkins-agent
@@ -37,6 +37,7 @@
 # * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins controller. When this is set,
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
+# * REMOTING_OPTS:             Generic way to pass additional options to pass to the remoting library
 
 if [ $# -eq 1 ] && [ "${1#-}" = "$1" ] ; then
 
@@ -126,6 +127,6 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $REMOTING_OPTS "$@"
 
 fi

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -26,6 +26,9 @@
 # Optional environment variables :
 # * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
+# * REMOTING_OPTS : Generic way to pass additional CLI options to agent.jar (see -help)
+#
+# Deprecated environment variables (prefer setting REMOTING_OPTS)
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument
@@ -37,7 +40,6 @@
 # * JENKINS_INSTANCE_IDENTITY: The base64 encoded InstanceIdentity byte array of the Jenkins controller. When this is set,
 #                              the agent skips connecting to an HTTP(S) port for connection info.
 # * JENKINS_PROTOCOLS:         Specify the remoting protocols to attempt when instanceIdentity is provided.
-# * REMOTING_OPTS:             Generic way to pass additional options to pass to the remoting library
 
 if [ $# -eq 1 ] && [ "${1#-}" = "$1" ] ; then
 

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -34,7 +34,8 @@ Param(
     $Protocols = '',
     $JenkinsJavaBin = '',
     $JavaHome = $env:JAVA_HOME,
-    $JenkinsJavaOpts = ''
+    $JenkinsJavaOpts = '',
+    $RemotingOpts = ''
 )
 
 # Usage jenkins-agent.ps1 [options] -Url http://jenkins -Secret [SECRET] -Name [AGENT_NAME]
@@ -70,6 +71,7 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
         'DirectConnection' = 'JENKINS_DIRECT_CONNECTION';
         'InstanceIdentity' = 'JENKINS_INSTANCE_IDENTITY';
         'Protocols' = 'JENKINS_PROTOCOLS';
+        'RemotingOpts' = 'REMOTING_OPTS';
     }
 
     # this does some trickery to update the variable from the CmdletBinding
@@ -107,6 +109,10 @@ if(![System.String]::IsNullOrWhiteSpace($Cmd)) {
     $AgentArguments += @("-jar", "C:/ProgramData/Jenkins/agent.jar")
     $AgentArguments += @("-secret", $Secret)
     $AgentArguments += @("-name", $Name)
+
+    if(![System.String]::IsNullOrWhiteSpace($RemotingOpts)) {
+        $AgentArguments += Invoke-Expression "echo $RemotingOpts"
+    }
 
     if(![System.String]::IsNullOrWhiteSpace($Tunnel)) {
         $AgentArguments += @("-tunnel", "`"$Tunnel`"")

--- a/jenkins-agent.ps1
+++ b/jenkins-agent.ps1
@@ -42,6 +42,9 @@ Param(
 # Optional environment variables :
 # * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
+# * REMOTING_OPTS : Generic way to pass additional CLI options to agent.jar (see -help)
+#
+# Deprecated environment variables (prefer setting REMOTING_OPTS)
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 # * JENKINS_SECRET : agent secret, if not set as an argument


### PR DESCRIPTION
https://github.com/jenkinsci/docker-agent/pull/802#issuecomment-2098889201

This deprecates existing environment variables allowing to set options to `agent.jar`. Going forward, this will ease addition or removal of options to `agent.jar` without impacting these launcher scripts.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
