### PR TITLE
hotfix(updatecli): remove remnant of jdk21-preview

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -29,17 +29,6 @@ function get_jdk_download_url() {
       ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    21*-ea-beta)
-      # JDK preview version (21+35-ea-beta, 21.0.1+12-ea-beta)
-      # This has been updated to support the new inferred URL pattern that started as of 21.0.3+2-ea-beta. It will not work for earlier preview versions.
-      # One could update the cases to support all preview versions, if desired.
-      jdk_version="${jdk_version//-beta}"
-      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
-      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12-ea-beta/OpenJDK21U-jdk_x64_linux_hotspot_ea_21-0-1-12.tar.gz
-      dashJDKVersion="${jdk_version//+/_}"
-      jdk_version="${jdk_version//-ea}"
-      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_${dashJDKVersion}"
-      return 0;;
     21*)
       ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}";

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -36,16 +36,6 @@ targets:
         keyword: "ARG"
         matcher: "DEBIAN_RELEASE"
     scmid: default
-  updatePreviewDockerfile:
-    name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the preview Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: debian/preview/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "DEBIAN_RELEASE"
-    scmid: default
   updateDockerBake:
     name: "Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl"
     kind: hcl


### PR DESCRIPTION
This PR removes remnants of jdk21-preview preventing updatecli to run correctly: https://github.com/jenkinsci/docker-agent/actions/runs/9548455384/job/26315680774

Follow-up of:
- #822 

cc @gounthar 

### Testing done

CI
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
