### PR TITLE
chore(Windows): add `-TestsDebug` parameter to build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,10 +6,17 @@ Param(
     [String] $AgentType = '',
     [String] $BuildNumber = '1',
     [switch] $DisableEnvProps = $false,
-    [switch] $DryRun = $false
+    [switch] $DryRun = $false,
+    # Output debug info for tests: 'empty' (no additional test output), 'debug' (test cmd & stderr outputed), 'verbose' (test cmd, stderr, stdout outputed)
+    [String] $TestsDebug = ''
 )
 
 $ErrorActionPreference = 'Stop'
+
+if(![String]::IsNullOrWhiteSpace($env:TESTS_DEBUG)) {
+    $TestsDebug = $env:TESTS_DEBUG
+}
+$env:TESTS_DEBUG = $TestsDebug
 
 $originalDockerComposeFile = 'build-windows.yaml'
 $finalDockerComposeFile = 'build-windows-current.yaml'

--- a/tests/test_helpers.psm1
+++ b/tests/test_helpers.psm1
@@ -97,10 +97,7 @@ function Is-ContainerRunning($container='') {
     }
 }
 
-function Run-Program($cmd, $params, $quiet=$true) {
-    if(-not $quiet) {
-        Write-Host "cmd & params: $cmd $params"
-    }
+function Run-Program($cmd, $params) {
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.CreateNoWindow = $true
     $psi.UseShellExecute = $false
@@ -115,13 +112,15 @@ function Run-Program($cmd, $params, $quiet=$true) {
     $stdout = $proc.StandardOutput.ReadToEnd()
     $stderr = $proc.StandardError.ReadToEnd()
     $proc.WaitForExit()
-    if(($proc.ExitCode -ne 0) -and (-not $quiet)) {
-        Write-Host "[err] stdout:`n$stdout"
-        Write-Host "[err] stderr:`n$stderr"
-        Write-Host "[err] cmd:`n$cmd"
-        Write-Host "[err] params:`n$param"
+    if (($env:TESTS_DEBUG -eq 'debug') -or ($env:TESTS_DEBUG -eq 'verbose')) {
+        Write-Host -ForegroundColor DarkBlue "[cmd] $cmd $params"
+        if ($env:TESTS_DEBUG -eq 'verbose') {
+            Write-Host -ForegroundColor DarkGray "[stdout] $stdout"
+        }
+        if ($proc.ExitCode -ne 0){
+            Write-Host -ForegroundColor DarkRed "[stderr] $stderr"
+        }
     }
-
     return $proc.ExitCode, $stdout, $stderr
 }
 


### PR DESCRIPTION
This PR introduces `-TestsDebug` parameter to build.ps1.

With it we can use `-TestsDebug` parameter or `$env:TESTS_DEBUG` to improve Windows tests debugging:
  - As it can be passed in the Jenkinsfile, it's easy now to activate it on a build replay instead of having to add a commit to switch debug on or off.
  - This parameter can take the following values:
    - empty/undefined: no additional debug (default value).
    - `debug`: output every test command and stderr on top of every test. (Equivalent of setting `$quiet=$true` in the  test_helpers "Run-Program" function currently)
    - `verbose`: same as `debug` + output of stdout.

<details><summary>Output (from docker-ssh-agent pull request):</summary>
<br>

With `.\build.ps1 test -TestsDebug 'debug'`:
<img width="703" alt="image" src="https://github.com/jenkinsci/docker-ssh-agent/assets/91831478/2e6d22ec-6ec0-458d-a518-1168b7527a2e">

With `.\build.ps1 test -TestsDebug 'verbose'`:
<img width="714" alt="image" src="https://github.com/jenkinsci/docker-ssh-agent/assets/91831478/57be11cd-002b-4e6d-87f6-3e624a231feb">

</details>

Similar to:
- https://github.com/jenkinsci/docker-ssh-agent/pull/396

### Testing done

Local tests + CI

Replay with `-TestsDebug` set to "verbose" and only one Windows image type to validate the functionality:
- <details><summary>diff</summary>
  
  ```diff
  --- old/Jenkinsfile
  +++ new/Jenkinsfile
  @@ -24,7 +24,7 @@
                   axes {
                       axis {
                           name 'IMAGE_TYPE'
  -                        values 'linux', 'nanoserver-1809', 'nanoserver-ltsc2019', 'nanoserver-ltsc2022', 'windowsservercore-1809', 'windowsservercore-ltsc2019', 'windowsservercore-ltsc2022'
  +                        values 'nanoserver-1809'
                       }
                   }
                   stages {
  @@ -63,7 +63,7 @@
                                               // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
                                               sh 'docker buildx bake --file docker-bake.hcl linux'
                                           } else {
  -                                            powershell '& ./build.ps1 test'
  +                                            powershell '& ./build.ps1 test -TestsDebug verbose'
                                           }
                                       }
                                   }
  ```
  
  </details>
 - https://ci.jenkins.io/job/Packaging/job/docker-agent/job/PR-828/2/

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

