### PR TITLE
Fix Debian-based Docker image `org.opencontainers.image.source` label

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -143,7 +143,7 @@ LABEL \
   org.opencontainers.image.description="This is an image for Jenkins agents using TCP or WebSockets to establish inbound connection to the Jenkins controller" \
   org.opencontainers.image.version="${VERSION}" \
   org.opencontainers.image.url="https://www.jenkins.io/" \
-  org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent-inbound" \
+  org.opencontainers.image.source="https://github.com/jenkinsci/docker-agent" \
   org.opencontainers.image.licenses="MIT"
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]


### PR DESCRIPTION
This should hopefully™️ help retrieving correct changelog information in Renovate PRs such as https://github.com/jenkinsci/helm-charts/pull/1135. It also fixes broken `source` link in the PR table.

### Testing done

Not tested yet. Based on [Renovate documentation](https://docs.renovatebot.com/key-concepts/changelogs/#how-renovate-detects-changelogs), this URL must be correct, so that it can detect the changelog.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
