### PR TITLE
Bugfix: Fix regression where environment variables set to USER would be lowercased to user.

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -105,7 +105,7 @@ RUN mkdir -p /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-ENV user=${user}
+ENV USER=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/archlinux/Dockerfile
+++ b/archlinux/Dockerfile
@@ -83,7 +83,7 @@ RUN mkdir /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-ENV user=${user}
+ENV USER=${user}
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -116,7 +116,7 @@ RUN mkdir -p /home/"${user}"/.jenkins && mkdir -p "${AGENT_WORKDIR}"
 VOLUME /home/"${user}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR /home/"${user}"
-ENV user=${user}
+ENV USER=${user}
 LABEL \
   org.opencontainers.image.vendor="Jenkins project" \
   org.opencontainers.image.title="Official Jenkins Agent Base Docker image" \

--- a/tests/tests_agent.bats
+++ b/tests/tests_agent.bats
@@ -171,5 +171,5 @@ ARCH=${ARCH:-x86_64}
 }
 
 @test "[${SUT_IMAGE}] default user is exposed in the environment" {
-  docker inspect --format '{{ .Config.Env }}' "${SUT_IMAGE}" | grep 'user=jenkins'
+  docker inspect --format '{{ .Config.Env }}' "${SUT_IMAGE}" | grep 'USER=jenkins'
 }

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -90,8 +90,8 @@ ARG AGENT_FILENAME=agent.jar
 ARG AGENT_HASH_FILENAME=$AGENT_FILENAME.sha1
 
 RUN net accounts /maxpwage:unlimited ; `
-    net user "$env:user" /add /expire:never /passwordreq:no ; `
-    net localgroup Administrators /add $env:user ; `
+    net user "$env:USER" /add /expire:never /passwordreq:no ; `
+    net localgroup Administrators /add $env:USER ; `
     New-Item -ItemType Directory -Path C:/ProgramData/Jenkins | Out-Null
 
 ARG AGENT_ROOT=C:/Users/$user

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -117,7 +117,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-ENV user=${user}
+ENV USER=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -110,7 +110,7 @@ RUN git config --global core.longpaths true
 VOLUME "${AGENT_ROOT}"/.jenkins
 VOLUME "${AGENT_WORKDIR}"
 WORKDIR "${AGENT_ROOT}"
-ENV user=${user}
+ENV USER=${user}
 LABEL `
     org.opencontainers.image.vendor="Jenkins project" `
     org.opencontainers.image.title="Official Jenkins Agent Base Docker image" `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -82,9 +82,9 @@ ARG AGENT_FILENAME=agent.jar
 ARG AGENT_HASH_FILENAME=$AGENT_FILENAME.sha1
 
 RUN net accounts /maxpwage:unlimited ; `
-    net user "$env:user" /add /expire:never /passwordreq:no ; `
-    net localgroup Administrators /add $env:user ; `
-    Set-LocalUser -Name $env:user -PasswordNeverExpires 1; `
+    net user "$env:USER" /add /expire:never /passwordreq:no ; `
+    net localgroup Administrators /add $env:USER ; `
+    Set-LocalUser -Name $env:USER -PasswordNeverExpires 1; `
     New-Item -ItemType Directory -Path C:/ProgramData/Jenkins | Out-Null
 
 ARG AGENT_ROOT=C:/Users/$user


### PR DESCRIPTION
https://github.com/jenkinsci/docker-agent/issues/858 (this will be moved at some point)

Fixes issue with environment variables named USER being set to user due to it being merged with the variable set in the Dockerfile.

### Testing done

<!-- Comment:
1. Built the inbound agent using the makefile and pushed the image to private registry.
2. Modified the Kubernetes agent to use the new sidecar
3. Validated user was set to USER instead of user.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira (Waiting for issue to be moved)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ N/A ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
