### PR TITLE
Add support for Jenkins agent jar file location in the environment variable JENKINS_AGENT_FILE

### DIFF
--- a/README_inbound-agent.md
+++ b/README_inbound-agent.md
@@ -61,6 +61,7 @@ Optional environment variables:
 
 * `JENKINS_JAVA_BIN`: Path to Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 * `JENKINS_JAVA_OPTS` : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS, **Warning** :exclamation: For more information on Windows usage, please see the **Windows Jenkins Java Opts** [section below](#windows-jenkins-java-opts).
+* `JENKINS_AGENT_FILE` : Jenkins agent jar file location, `/usr/share/jenkins/agent.jar` will be used if this is not set
 * `JENKINS_URL`: url for the Jenkins server, can be used as a replacement to `-url` option, or to set alternate jenkins URL
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins controller. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 * `JENKINS_SECRET`: (use only if not set as an argument) the secret as shown on the controller after creating the agent

--- a/jenkins-agent
+++ b/jenkins-agent
@@ -26,6 +26,7 @@
 # Optional environment variables :
 # * JENKINS_JAVA_BIN : Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 # * JENKINS_JAVA_OPTS : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS
+# * JENKINS_AGENT_FILE : Jenkins agent jar file location, /usr/share/jenkins/agent.jar will be used if this is not set
 # * REMOTING_OPTS : Generic way to pass additional CLI options to agent.jar (see -help)
 #
 # Deprecated environment variables (prefer setting REMOTING_OPTS)
@@ -109,6 +110,12 @@ else
 		fi
 	fi
 
+	if [ "$JENKINS_AGENT_FILE" ]; then
+		AGENT_FILE="$JENKINS_AGENT_FILE"
+	else
+		AGENT_FILE="/usr/share/jenkins/agent.jar"
+	fi
+
 	# if both required options are defined, do not pass the parameters
 	if [ -n "$JENKINS_SECRET" ]; then
 		case "$@" in
@@ -129,6 +136,6 @@ else
 	#TODO: Handle the case when the command-line and Environment variable contain different values.
 	#It is fine it blows up for now since it should lead to an error anyway.
 
-        exec $JAVA_BIN $JAVA_OPTIONS -jar /usr/share/jenkins/agent.jar $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $REMOTING_OPTS "$@"
+        exec $JAVA_BIN $JAVA_OPTIONS -jar $AGENT_FILE $SECRET $AGENT_NAME $TUNNEL $URL $WORKDIR $WEB_SOCKET $DIRECT $PROTOCOLS $INSTANCE_IDENTITY $REMOTING_OPTS "$@"
 
 fi


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Fixes #859

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Currently, the Jenkins agent jar file location is hardcoded in `/usr/share/jenkins/agent.jar`.

The jar file may be downloaded by the user who does not have write permission to directory, `/usr/share/jenkins`.

It would be great if the location can be customized in the environment variable.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
