### PR TITLE
chore(temurin Adoptium install scripts) provide visibility for `curl` and retry downloads

### DIFF
--- a/adoptium-get-jdk-link.sh
+++ b/adoptium-get-jdk-link.sh
@@ -73,7 +73,7 @@ for ARCH in ${ARCHS}; do
     # Fetch the download URL from the Adoptium API
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
-    if ! RESPONSE=$(curl -fsI "${URL}"); then
+    if ! RESPONSE=$(curl --fail --silent --head "${URL}"); then
         echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
@@ -91,7 +91,7 @@ for ARCH in ${ARCHS}; do
 
     # Use curl to check if the URL is reachable
     # If the URL is not reachable, print an error message and exit the script with status 1
-    if ! curl -v -fs "${REDIRECTED_URL}" >/dev/null 2>&1; then
+    if ! curl --verbose --fail --silent "${REDIRECTED_URL}" >/dev/null 2>&1; then
         echo "${REDIRECTED_URL}" is not reachable for architecture "${ARCH}". >&2
         exit 1
     fi

--- a/adoptium-get-jdk-link.sh
+++ b/adoptium-get-jdk-link.sh
@@ -73,7 +73,7 @@ for ARCH in ${ARCHS}; do
     # Fetch the download URL from the Adoptium API
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
-    if ! RESPONSE=$(curl --fail --silent --show-error --head "${URL}"); then
+    if ! RESPONSE=$(curl --fail --silent --show-error --retry 5 --retry-connrefused --head "${URL}"); then
         echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
@@ -91,7 +91,7 @@ for ARCH in ${ARCHS}; do
 
     # Use curl to check if the URL is reachable
     # If the URL is not reachable, print an error message and exit the script with status 1
-    if ! curl --fail --silent --show-error "${REDIRECTED_URL}" >/dev/null 2>&1; then
+    if ! curl --fail --silent --show-error --retry 5 --retry-connrefused "${REDIRECTED_URL}" >/dev/null 2>&1; then
         echo "${REDIRECTED_URL}" is not reachable for architecture "${ARCH}". >&2
         exit 1
     fi

--- a/adoptium-get-jdk-link.sh
+++ b/adoptium-get-jdk-link.sh
@@ -73,7 +73,7 @@ for ARCH in ${ARCHS}; do
     # Fetch the download URL from the Adoptium API
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
-    if ! RESPONSE=$(curl --fail --silent --head "${URL}"); then
+    if ! RESPONSE=$(curl --fail --silent --show-error --head "${URL}"); then
         echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
@@ -91,7 +91,7 @@ for ARCH in ${ARCHS}; do
 
     # Use curl to check if the URL is reachable
     # If the URL is not reachable, print an error message and exit the script with status 1
-    if ! curl --verbose --fail --silent "${REDIRECTED_URL}" >/dev/null 2>&1; then
+    if ! curl --fail --silent --show-error "${REDIRECTED_URL}" >/dev/null 2>&1; then
         echo "${REDIRECTED_URL}" is not reachable for architecture "${ARCH}". >&2
         exit 1
     fi

--- a/adoptium-install-jdk.sh
+++ b/adoptium-install-jdk.sh
@@ -28,7 +28,7 @@ if ! DOWNLOAD_URL=$("${SCRIPT_DIR}"/adoptium-get-jdk-link.sh "${JAVA_VERSION}" "
 fi
 
 # Use curl to download the JDK archive from the URL
-if ! curl --silent --show-error --location --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
+if ! curl --silent --show-error --location --retry 5 --retry-connrefused --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
     echo "Error: Failed to download the JDK archive. Exiting with status 1." >&2
     exit 1
 fi

--- a/adoptium-install-jdk.sh
+++ b/adoptium-install-jdk.sh
@@ -28,7 +28,7 @@ if ! DOWNLOAD_URL=$("${SCRIPT_DIR}"/adoptium-get-jdk-link.sh "${JAVA_VERSION}" "
 fi
 
 # Use curl to download the JDK archive from the URL
-if ! curl --silent --location --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
+if ! curl --silent --show-error --location --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
     echo "Error: Failed to download the JDK archive. Exiting with status 1." >&2
     exit 1
 fi


### PR DESCRIPTION
### Testing done

Recent PRs did fail to build with error returned while downloading the Temurin archives.

This changes introduces the 2 following element to avoid these build failures:

- Enable (exponential backoff) retries 
- Have `curl` printing the error when it happens (otherwise the use of the `--silent` flags hides the information)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
