### PR TITLE
chore(Jenkinsfile) fix `withEnv` syntax error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,10 @@ pipeline {
                                     script {
                                         def tagItems = env.TAG_NAME.split('-')
                                         if(tagItems.length == 2) {
-                                            withEnv(["REMOTING_VERSION=${tagItems[0]}", "BUILD_NUMBER=${tagItems[1]}"]) {
+                                            withEnv([
+                                                "REMOTING_VERSION=${tagItems[0]}",
+                                                "BUILD_NUMBER=${tagItems[1]}",
+                                            ]) {
                                                 // This function is defined in the jenkins-infra/pipeline-library
                                                 infra.withDockerCredentials {
                                                     if (isUnix()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,10 +81,7 @@ pipeline {
                                     script {
                                         def tagItems = env.TAG_NAME.split('-')
                                         if(tagItems.length == 2) {
-                                            withEnv(
-                                                ["REMOTING_VERSION=${tagItems[0]}"],
-                                                ["BUILD_NUMBER=${tagItems[1]}"]
-                                            ) {
+                                            withEnv(["REMOTING_VERSION=${tagItems[0]}", "BUILD_NUMBER=${tagItems[1]}"]) {
                                                 // This function is defined in the jenkins-infra/pipeline-library
                                                 infra.withDockerCredentials {
                                                     if (isUnix()) {


### PR DESCRIPTION
This PR fixes the deployment error specified in https://github.com/jenkinsci/docker-agent/pull/827#issuecomment-2371752625

### Testing done

None (for now). Gotta run a replay with no "push" on trusted.ci

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- ~[ ] Ensure that the pull request title represents the desired changelog entry~ (skiping changelog)
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~ (hard to test)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
