### PR TITLE
doc: use absolute link in README_agent.md

### DIFF
--- a/README_agent.md
+++ b/README_agent.md
@@ -10,7 +10,7 @@ Java version depends on the image and the platform, see the _Configurations_ sec
 
 ## Usage
 
-This image is used as the basis for the [Docker Inbound Agent](README_inbound-agent.md) image.
+This image is used as the basis for the [Docker Inbound Agent](https://github.com/jenkinsci/docker-agent/tree/master/README_inbound-agent.md) image.
 In that image, the container is launched externally and attaches to Jenkins.
 
 This image may instead be used to launch an agent using the **Launch method** of **Launch agent via execution of command on the controller**. For example on Linux you can try


### PR DESCRIPTION
This PR replaces the relative link introduced in #888 by an absolute one as this README is used on https://hub.docker.com/r/jenkins/agent/

Ref:
- https://github.com/jenkinsci/docker-agent/pull/888#issuecomment-2390721078

### Testing done

N/A

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
