### PR TITLE
chore(updatecli) fix UBI9 manifest

### DIFF
--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -17,8 +17,10 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
 fi
 
 # Fetch the tags using curl
-curl --silent --fail --location --verbose --header 'accept: application/json' "$URL" \
+latest_tag="$(curl --silent --fail --location --verbose --header 'accept: application/json' "$URL" \
     | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]' \
-    | xargs `# Trim eventual whitespaces`
+    | xargs `# Trim eventual whitespaces`)"
+
+[ -z "$latest_tag" ] || exit 1
 
 exit 0

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -12,25 +12,26 @@ URL="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry
 # Check if jq and curl are installed
 # If they are not installed, exit the script with an error message
 if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
-    echo "jq and curl are required but not installed. Exiting with status 1." >&2
+    >&2 echo "jq and curl are required but not installed. Exiting with status 1." >&2
     exit 1
 fi
 
 # Fetch the tags using curl
-response=$(curl -s "$URL" -H 'accept: application/json')
+# curl --silent --fail --location --header 'accept: application/json' "$URL"
+response=$(curl --silent --fail --location --verbose --header 'accept: application/json' "$URL")
 
 # Check if the response is empty or null
 if [ -z "$response" ] || [ "$response" == "null" ]; then
-  echo "Error: Failed to fetch tags from the Red Hat Container Catalog API."
+  >&2 echo "Error: Failed to fetch tags from the Red Hat Container Catalog API."
   exit 1
 fi
 
 # Parse the JSON response using jq to find the "latest" tag and its associated tags
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[].signatures[] | select(.tags[] == "latest") | .tags[]')
+latest_tag="$(echo "$response" | jq '.data[].repositories[].signatures[].tags' | jq -s 'flatten(1) | first')"
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then
-  echo "Error: No valid tags found."
+  >&2 echo "Error: No valid tags found."
   exit 1
 fi
 
@@ -39,4 +40,5 @@ unique_tag=$(echo "$latest_tag" | sort | uniq | grep -v latest | grep "-")
 
 # Trim spaces
 unique_tag=$(echo "$unique_tag" | xargs)
-echo $unique_tag
+echo "$unique_tag"
+exit 0

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -17,27 +17,8 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
 fi
 
 # Fetch the tags using curl
-response=$(curl --silent --fail --location --verbose --header 'accept: application/json' "$URL")
+curl --silent --fail --location --verbose --header 'accept: application/json' "$URL" \
+    | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]') \
+    | xargs `# Trim eventual whitespaces`
 
-# Check if the response is empty or null
-if [ -z "$response" ] || [ "$response" == "null" ]; then
-  >&2 echo "Error: Failed to fetch tags from the Red Hat Container Catalog API."
-  exit 1
-fi
-
-# Parse the JSON response using jq to find the "latest" tag and its associated tags
-latest_tag="$(echo "$response" | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]')"
-
-# Check if the latest_tag is empty
-if [ -z "$latest_tag" ]; then
-  >&2 echo "Error: No valid tags found."
-  exit 1
-fi
-
-# Sort and remove duplicates
-unique_tag=$(echo "$latest_tag" | sort | uniq | grep -v latest | grep "-")
-
-# Trim spaces
-unique_tag=$(echo "$unique_tag" | xargs)
-echo "$unique_tag"
 exit 0

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -18,7 +18,7 @@ fi
 
 # Fetch the tags using curl
 curl --silent --fail --location --verbose --header 'accept: application/json' "$URL" \
-    | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]') \
+    | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]' \
     | xargs `# Trim eventual whitespaces`
 
 exit 0

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -26,7 +26,7 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
 fi
 
 # Parse the JSON response using jq to find the "latest" tag and its associated tags
-latest_tag="$(echo "$response" | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]'"
+latest_tag="$(echo "$response" | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]')"
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -21,6 +21,6 @@ latest_tag="$(curl --silent --fail --location --verbose --header 'accept: applic
     | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]' \
     | xargs `# Trim eventual whitespaces`)"
 
-[ -z "$latest_tag" ] || exit 1
+[ -n "$latest_tag" ] || exit 1
 
 exit 0

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -27,7 +27,7 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
 fi
 
 # Parse the JSON response using jq to find the "latest" tag and its associated tags
-latest_tag="$(echo "$response" | jq '.data[].repositories[].signatures[].tags' | jq -s 'flatten(1) | first')"
+latest_tag="$(echo "$response" | jq --sort-keys 'first(.data[].repositories[].signatures[].tags)[]'"
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -17,7 +17,6 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
 fi
 
 # Fetch the tags using curl
-# curl --silent --fail --location --header 'accept: application/json' "$URL"
 response=$(curl --silent --fail --location --verbose --header 'accept: application/json' "$URL")
 
 # Check if the response is empty or null

--- a/updatecli/updatecli.d/rhel-ubi9.yaml
+++ b/updatecli/updatecli.d/rhel-ubi9.yaml
@@ -1,6 +1,4 @@
 ---
-# This YAML configuration file is used to bump the UBI9 version in the Dockerfile and docker-bake.hcl and create a pull request with the changes.
-
 name: Bump UBI9 version
 
 scms:
@@ -17,49 +15,51 @@ scms:
 
 sources:
   latestVersion:
-    name: "Get the latest UBI9 Linux version" # Source to get the latest UBI9 version
+    name: "Get the latest UBI9 Linux version"
     kind: shell
     spec:
-      command: bash updatecli/scripts/ubi9-latest-tag.sh # Command to fetch the latest UBI9 tag
+      command: bash -x updatecli/scripts/ubi9-latest-tag.sh
 
 conditions:
   checkUbi9DockerImage:
     kind: dockerimage
-    name: Check if the container image "ubi9" is available # Condition to check if the UBI9 Docker image is available
+    name: Check if the container image "ubi9" is available
+    sourceid: latestVersion # Provides the found tag as "input"
     spec:
       architectures:
         - linux/amd64
         - linux/arm64
         - linux/s390x
         - linux/ppc64le
-      image: registry.access.redhat.com/ubi9 # Docker image to check. The tag is automatically set to the version found in the only source
+      image: registry.access.redhat.com/ubi9
+
 
 targets:
   updateDockerfile:
-    name: "Update the value of the base image (ARG UBI9_TAG) in the Dockerfile" # Target to update the Dockerfile with the new UBI9 tag
+    name: "Update the value of the base image (ARG UBI9_TAG) in the Dockerfile"
     kind: dockerfile
     sourceid: latestVersion
     spec:
-      file: rhel/ubi9/Dockerfile # Path to the Dockerfile
+      file: rhel/ubi9/Dockerfile
       instruction:
-        keyword: "ARG" # Dockerfile instruction keyword
-        matcher: "UBI9_TAG" # Dockerfile instruction matcher
+        keyword: ARG
+        matcher: UBI9_TAG
     scmid: default
   updateDockerBake:
-    name: "Update the default value of the variable UBI9_TAG in the docker-bake.hcl" # Target to update the docker-bake.hcl file with the new UBI9 tag
+    name: "Update the default value of the variable UBI9_TAG in the docker-bake.hcl"
     kind: hcl
     sourceid: latestVersion
     spec:
-      file: docker-bake.hcl # Path to the docker-bake.hcl file
-      path: variable.UBI9_TAG.default # Path to the variable in the HCL file
+      file: docker-bake.hcl
+      path: variable.UBI9_TAG.default
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump UBI9 version to {{ source "latestVersion" }} # Title of the pull request
+    title: Bump UBI9 version to {{ source "latestVersion" }}
     spec:
       labels:
         - dependencies
-        - rhel-ubi9 # Labels for the pull request
+        - rhel-ubi9


### PR DESCRIPTION
This PR fixes the `updatecli` manifest which tracks the UBI9 base image versions.

It introduces the following changes:

- Fix the shell script to retrieve the first item of the list of tags found, since it's been sorted by "last updated".
  - It does not focus anymore on the `latest` tag
  - I believe it might fail in the future if the `X.Y` tags are updated after the "detailed" version. Let's see how it behaves. If it fails, then we'll have to sort ourselves (removing `latest` and `X.Y`, then sort the list, then get the first item)
  - Utilizes long flags for `curl`
  - Write to stderr, so `updatecli` could benefit from a better reporting
  - Run as debug (write debug log to stderr, while source reads from stdout)
- Remove comment when they repeat the same information as the attribute

Check and local testing both reports incoming UBI 9 change:

```
⚠ Bump UBI9 version:
	Source:
		✔ [latestVersion] Get the latest UBI9 Linux version
	Condition:
		✔ [checkUbi9DockerImage] Check if the container image "ubi9" is available
	Target:
		⚠ [updateDockerBake] Update the default value of the variable UBI9_TAG in the docker-bake.hcl
		⚠ [updateDockerfile] Update the value of the base image (ARG UBI9_TAG) in the Dockerfile
```