### PR TITLE
chore: add tags functions to docker bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -74,6 +74,10 @@ variable "default_jdk" {
   default = 17
 }
 
+variable "jdks_in_preview" {
+  default = [25]
+}
+
 variable "JAVA17_VERSION" {
   default = "17.0.14_7"
 }
@@ -212,6 +216,77 @@ function "rhel_ubi9_platforms" {
   result = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }
 
+# Return the distribution followed by a dash if it is not the default distribution
+function distribution_prefix {
+  params = [distribution]
+  result = (equal("debian", distribution)
+    ? ""
+    : "${distribution}-")
+}
+
+# Return a dash followed by the distribution if it is not the default distribution
+function distribution_suffix {
+  params = [distribution]
+  result = (equal("debian", distribution)
+    ? ""
+    : "-${distribution}")
+}
+
+# Return the official name of the default distribution
+function distribution_name {
+  params = [distribution]
+  result = (equal("debian", distribution)
+    ? "bookworm"
+    : distribution)
+}
+
+# Return the tag suffixed by "-preview" if the jdk passed as parameter is in the jdks_in_preview list
+function preview_tag {
+  params = [jdk]
+  result = (contains(jdks_in_preview, jdk)
+    ? "${jdk}-preview"
+    : jdk)
+}
+
+# Return an array of tags depending on the agent type, the jdk and the Linux distribution passed as parameters
+function "linux_tags" {
+  params = [type, jdk, distribution]
+  result = [
+    ## All
+    # If there is a tag, add versioned tag suffixed by the jdk
+    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}-jdk${preview_tag(jdk)}" : "",
+
+    # If there is a tag and if the jdk is the default one, add versioned short tag
+    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}${distribution_suffix(distribution)}" : "") : "",
+
+    # If the jdk is the default one, add distribution and latest short tags
+    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}" : "",
+    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
+    # ":latest" tag for the default distribution. For other distributions, duplicate tag above (not an issue, deduplicated at the end)
+    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest${distribution_suffix(distribution)}" : "",
+
+    # Tags always added
+    "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
+    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
+    # Short tags for the default distribution. For other distributions, duplicate tag above (not an issue, deduplicated at the end)
+    "${REGISTRY}/${orgrepo(type)}:${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
+    "${REGISTRY}/${orgrepo(type)}:latest-${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
+  ]
+}
+
+# Return an array of tags depending on the agent type, the jdk and the flavor and version of Windows passed as parameters
+function "windows_tags" {
+  params = [type, jdk, flavor_and_version]
+  result = [
+    # If there is a tag, add versioned tag containing the jdk
+    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${preview_tag(jdk)}-${flavor_and_version}" : "",
+    # If there is a tag and if the jdk is the default one, add versioned and short tags
+    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-${flavor_and_version}" : "") : "",
+    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${flavor_and_version}" : "") : "",
+    "${REGISTRY}/${orgrepo(type)}:jdk${preview_tag(jdk)}-${flavor_and_version}",
+  ]
+}
+
 target "alpine" {
   matrix = {
     type = agent_types_to_build
@@ -226,23 +301,7 @@ target "alpine" {
     VERSION      = REMOTING_VERSION
     JAVA_VERSION = "${javaversion(jdk)}"
   }
-  tags = [
-    # If there is a tag, add versioned tags suffixed by the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine-jdk${jdk}" : "",
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine${ALPINE_SHORT_TAG}-jdk${jdk}" : "",
-    # If there is a tag and if the jdk is the default one, add Alpine short tags
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine" : "") : "",
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-alpine${ALPINE_SHORT_TAG}" : "") : "",
-    # If the jdk is the default one, add Alpine short tags
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:alpine" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:alpine${ALPINE_SHORT_TAG}" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-alpine" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-alpine${ALPINE_SHORT_TAG}" : "",
-    "${REGISTRY}/${orgrepo(type)}:alpine-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:latest-alpine-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:latest-alpine${ALPINE_SHORT_TAG}-jdk${jdk}",
-  ]
+  tags = concat(linux_tags(type, jdk, "alpine"), linux_tags(type, jdk, "alpine${ALPINE_SHORT_TAG}"))
   platforms = alpine_platforms(jdk)
 }
 
@@ -260,20 +319,7 @@ target "debian" {
     DEBIAN_RELEASE = DEBIAN_RELEASE
     JAVA_VERSION   = "${javaversion(jdk)}"
   }
-  tags = [
-    # If there is a tag, add versioned tag suffixed by the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${jdk}" : "",
-    # If there is a tag and if the jdk is the default one, add versioned short tag
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}" : "") : "",
-    # If the jdk is the default one, add Debian and latest short tags
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:bookworm" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-bookworm" : "",
-    "${REGISTRY}/${orgrepo(type)}:bookworm-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:latest-bookworm-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:latest-jdk${jdk}",
-  ]
+  tags = linux_tags(type, jdk, "debian")
   platforms = debian_platforms(jdk)
 }
 
@@ -291,17 +337,7 @@ target "rhel_ubi9" {
     VERSION      = REMOTING_VERSION
     JAVA_VERSION = "${javaversion(jdk)}"
   }
-  tags = [
-    # If there is a tag, add versioned tag suffixed by the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-rhel-ubi9-jdk${jdk}" : "",
-    # If there is a tag and if the jdk is the default one, add versioned short tag
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-rhel-ubi9" : "") : "",
-    # If the jdk is the default one, add rhel and latest short tags
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:rhel-ubi9" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-rhel-ubi9" : "",
-    "${REGISTRY}/${orgrepo(type)}:rhel-ubi9-jdk${jdk}",
-    "${REGISTRY}/${orgrepo(type)}:latest-rhel-ubi9-jdk${jdk}",
-  ]
+  tags = linux_tags(type, jdk, "rhel-ubi9")
   platforms = rhel_ubi9_platforms(jdk)
 }
 
@@ -322,14 +358,7 @@ target "nanoserver" {
     WINDOWS_VERSION_TAG   = windows_version
   }
   target = type
-  tags = [
-    # If there is a tag, add versioned tag containing the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${jdk}-nanoserver-${windows_version}" : "",
-    # If there is a tag and if the jdk is the default one, add versioned and short tags
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-nanoserver-${windows_version}" : "") : "",
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:nanoserver-${windows_version}" : "") : "",
-    "${REGISTRY}/${orgrepo(type)}:jdk${jdk}-nanoserver-${windows_version}",
-  ]
+  tags = windows_tags(type, jdk, "nanoserver-${windows_version}")
   platforms = ["windows/amd64"]
 }
 
@@ -350,13 +379,6 @@ target "windowsservercore" {
     WINDOWS_VERSION_TAG   = windows_version
   }
   target = type
-  tags = [
-    # If there is a tag, add versioned tag containing the jdk
-    equal(ON_TAG, "true") ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-jdk${jdk}-windowsservercore-${windows_version}" : "",
-    # If there is a tag and if the jdk is the default one, add versioned and short tags
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${REMOTING_VERSION}-${BUILD_NUMBER}-windowsservercore-${windows_version}" : "") : "",
-    equal(ON_TAG, "true") ? (is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:windowsservercore-${windows_version}" : "") : "",
-    "${REGISTRY}/${orgrepo(type)}:jdk${jdk}-windowsservercore-${windows_version}",
-  ]
+  tags = windows_tags(type, jdk, "windowsservercore-${windows_version}")
   platforms = ["windows/amd64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -261,14 +261,14 @@ function "linux_tags" {
 
     # If the jdk is the default one, add distribution and latest short tags
     is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}" : "",
-    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
-    # ":latest" tag for the default distribution. For other distributions, duplicate tag above (not an issue, deduplicated at the end)
     is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest${distribution_suffix(distribution)}" : "",
+    # Needed for the ":latest-bookworm" case. For other distributions, result in the same tag as above (not an issue, deduplicated at the end)
+    is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
 
     # Tags always added
     "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
     "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}-jdk${preview_tag(jdk)}",
-    # Short tags for the default distribution. For other distributions, duplicate tag above (not an issue, deduplicated at the end)
+    # ":jdkN" and ":latest-jdkN" short tags for the default distribution. For other distributions, result in the tags above (not an issue, deduplicated at the end)
     "${REGISTRY}/${orgrepo(type)}:${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
     "${REGISTRY}/${orgrepo(type)}:latest-${distribution_prefix(distribution)}jdk${preview_tag(jdk)}",
   ]


### PR DESCRIPTION
This PR adds `linux_tags` and `windows_tags` functions to regroup Docker image tags definition so we don't have to change every target block when introducing a new JDK, and to avoid errors and/or inconsistencies.

It takes in account JDK in preview so we don't have to deal with it everywhere.

### Testing done

With #945, compared the output of `make show-linux` and `make show-windows` from the primary branch and from this PR branch, no change, same results.
```
ON_TAG=true BUILD_NUMBER=3 make show-linux | jq -r ".target | .[].tags | .[]" | sort
ON_TAG=true BUILD_NUMBER=3 make show-windows | jq -r ".target | .[].tags | .[]" | sort
```

Also checked the output when adding '25' to the `jdks_to_build` list to ensure the work done by @gounthar in #939 could use it without issue:
<details><summary>Linux tags</summary>

```
docker.io/jenkins/agent:3283.v92c105e0f819-3
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine-jdk17
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine-jdk21
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine-jdk25-preview
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21-jdk17
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21-jdk21
docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21-jdk25-preview
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview
docker.io/jenkins/agent:3283.v92c105e0f819-3-rhel-ubi9
docker.io/jenkins/agent:3283.v92c105e0f819-3-rhel-ubi9-jdk17
docker.io/jenkins/agent:3283.v92c105e0f819-3-rhel-ubi9-jdk21
docker.io/jenkins/agent:3283.v92c105e0f819-3-rhel-ubi9-jdk25-preview
docker.io/jenkins/agent:alpine
docker.io/jenkins/agent:alpine-jdk17
docker.io/jenkins/agent:alpine-jdk21
docker.io/jenkins/agent:alpine-jdk25-preview
docker.io/jenkins/agent:alpine3.21
docker.io/jenkins/agent:alpine3.21-jdk17
docker.io/jenkins/agent:alpine3.21-jdk21
docker.io/jenkins/agent:alpine3.21-jdk25-preview
docker.io/jenkins/agent:bookworm
docker.io/jenkins/agent:bookworm-jdk17
docker.io/jenkins/agent:bookworm-jdk21
docker.io/jenkins/agent:bookworm-jdk25-preview
docker.io/jenkins/agent:jdk17
docker.io/jenkins/agent:jdk21
docker.io/jenkins/agent:jdk25-preview
docker.io/jenkins/agent:latest
docker.io/jenkins/agent:latest-alpine
docker.io/jenkins/agent:latest-alpine-jdk17
docker.io/jenkins/agent:latest-alpine-jdk21
docker.io/jenkins/agent:latest-alpine-jdk25-preview
docker.io/jenkins/agent:latest-alpine3.21
docker.io/jenkins/agent:latest-alpine3.21-jdk17
docker.io/jenkins/agent:latest-alpine3.21-jdk21
docker.io/jenkins/agent:latest-alpine3.21-jdk25-preview
docker.io/jenkins/agent:latest-bookworm
docker.io/jenkins/agent:latest-bookworm-jdk17
docker.io/jenkins/agent:latest-bookworm-jdk21
docker.io/jenkins/agent:latest-bookworm-jdk25-preview
docker.io/jenkins/agent:latest-jdk17
docker.io/jenkins/agent:latest-jdk21
docker.io/jenkins/agent:latest-jdk25-preview
docker.io/jenkins/agent:latest-rhel-ubi9
docker.io/jenkins/agent:latest-rhel-ubi9-jdk17
docker.io/jenkins/agent:latest-rhel-ubi9-jdk21
docker.io/jenkins/agent:latest-rhel-ubi9-jdk25-preview
docker.io/jenkins/agent:rhel-ubi9
docker.io/jenkins/agent:rhel-ubi9-jdk17
docker.io/jenkins/agent:rhel-ubi9-jdk21
docker.io/jenkins/agent:rhel-ubi9-jdk25-preview
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine-jdk17
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine-jdk21
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine-jdk25-preview
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine3.21
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine3.21-jdk17
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine3.21-jdk21
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-alpine3.21-jdk25-preview
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-rhel-ubi9
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-rhel-ubi9-jdk17
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-rhel-ubi9-jdk21
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-rhel-ubi9-jdk25-preview
docker.io/jenkins/inbound-agent:alpine
docker.io/jenkins/inbound-agent:alpine-jdk17
docker.io/jenkins/inbound-agent:alpine-jdk21
docker.io/jenkins/inbound-agent:alpine-jdk25-preview
docker.io/jenkins/inbound-agent:alpine3.21
docker.io/jenkins/inbound-agent:alpine3.21-jdk17
docker.io/jenkins/inbound-agent:alpine3.21-jdk21
docker.io/jenkins/inbound-agent:alpine3.21-jdk25-preview
docker.io/jenkins/inbound-agent:bookworm
docker.io/jenkins/inbound-agent:bookworm-jdk17
docker.io/jenkins/inbound-agent:bookworm-jdk21
docker.io/jenkins/inbound-agent:bookworm-jdk25-preview
docker.io/jenkins/inbound-agent:jdk17
docker.io/jenkins/inbound-agent:jdk21
docker.io/jenkins/inbound-agent:jdk25-preview
docker.io/jenkins/inbound-agent:latest
docker.io/jenkins/inbound-agent:latest-alpine
docker.io/jenkins/inbound-agent:latest-alpine-jdk17
docker.io/jenkins/inbound-agent:latest-alpine-jdk21
docker.io/jenkins/inbound-agent:latest-alpine-jdk25-preview
docker.io/jenkins/inbound-agent:latest-alpine3.21
docker.io/jenkins/inbound-agent:latest-alpine3.21-jdk17
docker.io/jenkins/inbound-agent:latest-alpine3.21-jdk21
docker.io/jenkins/inbound-agent:latest-alpine3.21-jdk25-preview
docker.io/jenkins/inbound-agent:latest-bookworm
docker.io/jenkins/inbound-agent:latest-bookworm-jdk17
docker.io/jenkins/inbound-agent:latest-bookworm-jdk21
docker.io/jenkins/inbound-agent:latest-bookworm-jdk25-preview
docker.io/jenkins/inbound-agent:latest-jdk17
docker.io/jenkins/inbound-agent:latest-jdk21
docker.io/jenkins/inbound-agent:latest-jdk25-preview
docker.io/jenkins/inbound-agent:latest-rhel-ubi9
docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk17
docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk21
docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk25-preview
docker.io/jenkins/inbound-agent:rhel-ubi9
docker.io/jenkins/inbound-agent:rhel-ubi9-jdk17
docker.io/jenkins/inbound-agent:rhel-ubi9-jdk21
docker.io/jenkins/inbound-agent:rhel-ubi9-jdk25-preview
```

</details>

<details><summary>Windows tags</summary>

```
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17-nanoserver-1809
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17-nanoserver-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17-nanoserver-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17-windowsservercore-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk17-windowsservercore-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21-nanoserver-1809
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21-nanoserver-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21-nanoserver-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21-windowsservercore-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk21-windowsservercore-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-1809
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview-windowsservercore-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-jdk25-preview-windowsservercore-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-nanoserver-1809
docker.io/jenkins/agent:3283.v92c105e0f819-3-nanoserver-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-nanoserver-ltsc2022
docker.io/jenkins/agent:3283.v92c105e0f819-3-windowsservercore-ltsc2019
docker.io/jenkins/agent:3283.v92c105e0f819-3-windowsservercore-ltsc2022
docker.io/jenkins/agent:jdk17-nanoserver-1809
docker.io/jenkins/agent:jdk17-nanoserver-ltsc2019
docker.io/jenkins/agent:jdk17-nanoserver-ltsc2022
docker.io/jenkins/agent:jdk17-windowsservercore-ltsc2019
docker.io/jenkins/agent:jdk17-windowsservercore-ltsc2022
docker.io/jenkins/agent:jdk21-nanoserver-1809
docker.io/jenkins/agent:jdk21-nanoserver-ltsc2019
docker.io/jenkins/agent:jdk21-nanoserver-ltsc2022
docker.io/jenkins/agent:jdk21-windowsservercore-ltsc2019
docker.io/jenkins/agent:jdk21-windowsservercore-ltsc2022
docker.io/jenkins/agent:jdk25-preview-nanoserver-1809
docker.io/jenkins/agent:jdk25-preview-nanoserver-ltsc2019
docker.io/jenkins/agent:jdk25-preview-nanoserver-ltsc2022
docker.io/jenkins/agent:jdk25-preview-windowsservercore-ltsc2019
docker.io/jenkins/agent:jdk25-preview-windowsservercore-ltsc2022
docker.io/jenkins/agent:nanoserver-1809
docker.io/jenkins/agent:nanoserver-ltsc2019
docker.io/jenkins/agent:nanoserver-ltsc2022
docker.io/jenkins/agent:windowsservercore-ltsc2019
docker.io/jenkins/agent:windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17-nanoserver-1809
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk17-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21-nanoserver-1809
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk21-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-1809
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-jdk25-preview-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-nanoserver-1809
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:3283.v92c105e0f819-3-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:jdk17-nanoserver-1809
docker.io/jenkins/inbound-agent:jdk17-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:jdk17-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:jdk17-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:jdk17-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:jdk21-nanoserver-1809
docker.io/jenkins/inbound-agent:jdk21-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:jdk21-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:jdk21-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:jdk21-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:jdk25-preview-nanoserver-1809
docker.io/jenkins/inbound-agent:jdk25-preview-nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:jdk25-preview-nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:jdk25-preview-windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:jdk25-preview-windowsservercore-ltsc2022
docker.io/jenkins/inbound-agent:nanoserver-1809
docker.io/jenkins/inbound-agent:nanoserver-ltsc2019
docker.io/jenkins/inbound-agent:nanoserver-ltsc2022
docker.io/jenkins/inbound-agent:windowsservercore-ltsc2019
docker.io/jenkins/inbound-agent:windowsservercore-ltsc2022
```
</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
