### PR TITLE
chore: add `show-%` Makefile target and use `jdks_to_build` in `rhel_ubi9` bake target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ every-build: check-reqs
 show:
 	@$(bake_cli) linux --print
 
+show-%:
+	@$(bake_cli) $* --print
+
 list: check-reqs
 	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make every-build
 
 #### Other `make` targets
 
-`show` gives us a detailed view of the images that will be built, with the tags, platforms, and Dockerfiles.
+`show` (and `show-windows`) gives us a detailed view of the images that could be built, with all tags, platforms, and Dockerfiles.
 
 ```bash
 $ make show

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make every-build
 
 #### Other `make` targets
 
-`show` (and `show-windows`) gives us a detailed view of the images that could be built, with all tags, platforms, and Dockerfiles.
+`show` (and `show-windows`) gives us a detailed view of the images that could be built, with tags, platforms, and Dockerfiles.
 
 ```bash
 $ make show
@@ -168,6 +168,36 @@ $ make show
       ]
     },
     [...]
+```
+
+To view all tags, set `ON_TAG` (and eventually `BUILD_NUMBER`):
+```bash
+$ ON_TAG=true BUILD_NUMBER=3 make show
+[...]
+  "target": {
+    "agent_alpine_jdk17": {
+      "context": ".",
+      "dockerfile": "alpine/Dockerfile",
+      "args": {
+        "ALPINE_TAG": "3.21.3",
+        "JAVA_VERSION": "17.0.14_7",
+        "VERSION": "3283.v92c105e0f819"
+      },
+      "tags": [
+        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine-jdk17",
+        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21-jdk17",
+        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine",
+        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21",
+        "docker.io/jenkins/agent:alpine",
+        "docker.io/jenkins/agent:alpine3.21",
+        "docker.io/jenkins/agent:latest-alpine",
+        "docker.io/jenkins/agent:latest-alpine3.21",
+        "docker.io/jenkins/agent:alpine-jdk17",
+        "docker.io/jenkins/agent:alpine3.21-jdk17",
+        "docker.io/jenkins/agent:latest-alpine-jdk17",
+        "docker.io/jenkins/agent:latest-alpine3.21-jdk17"
+      ],
+      [...]
 ```
 
 `bats` is a dependency target. It will update the [`bats` submodule](https://github.com/bats-core/bats-core) and run the tests.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -280,7 +280,7 @@ target "debian" {
 target "rhel_ubi9" {
   matrix = {
     type = agent_types_to_build
-    jdk  = [17, 21]
+    jdk  = jdks_to_build
   }
   name       = "${type}_rhel_ubi9_jdk${jdk}"
   target     = type


### PR DESCRIPTION
- add `show-%` Makefile target: allow debugging Windows targets on a Linux or MacOS machine.
- use `jdks_to_build` in `rhel_ubi9` bake target: follow-up of #890 

Extracted from:
- #944

### Testing done

Tested like #944 + CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
