### PR TITLE
chore: remove `linux-agent-only` and `linux-inbound-agent-only` groups

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -13,28 +13,6 @@ group "windows" {
   ]
 }
 
-group "linux-agent-only" {
-  targets = [
-    "agent_alpine_jdk17",
-    "agent_alpine_jdk21",
-    "agent_debian_jdk17",
-    "agent_debian_jdk21",
-    "agent_rhel_ubi9_jdk17",
-    "agent_rhel_ubi9_jdk21"
-  ]
-}
-
-group "linux-inbound-agent-only" {
-  targets = [
-    "inbound-agent_alpine_jdk17",
-    "inbound-agent_alpine_jdk21",
-    "inbound-agent_debian_jdk17",
-    "inbound-agent_debian_jdk21",
-    "inbound-agent_rhel_ubi9_jdk17",
-    "inbound-agent_rhel_ubi9_jdk21"
-  ]
-}
-
 group "linux-arm64" {
   targets = [
     "alpine_jdk21",


### PR DESCRIPTION
Reviewing #939 I realised these groups I've introduced in #570 are annoying to update: they can be updated manually only (error prone), and doesn't add any real functionality (not used anywhere in the code).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
