### PR TITLE
chore(Jenkinsfile) add support for retries with non Spot VMs on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ parallelStages = [failFast: false]
     'windowsservercore-ltsc2019',
     'windowsservercore-ltsc2022'
 ].each { imageType ->
-    parallelStages["Building ${imageType}"] = {
+    parallelStages[imageType] = {
         withEnv(["IMAGE_TYPE=${imageType}"]) {
             int retryCounter = 0
             retry(count: 2, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
@@ -54,6 +54,7 @@ parallelStages = [failFast: false]
                 retryCounter++
                 node(resolvedAgentLabel) {
                     timeout(time: 60, unit: 'MINUTES') {
+                        checkout scm
                         if (imageType == "linux") {
                             stage('Prepare Docker') {
                                 sh 'make docker-init'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ parallelStages = [failFast: false]
     'windowsservercore-ltsc2022'
 ].each { imageType ->
     parallelStages[imageType] = {
-        withEnv(["IMAGE_TYPE=${imageType}"]) {
+        withEnv(["IMAGE_TYPE=${imageType}", "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"]) {
             int retryCounter = 0
             retry(count: 2, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
                 // Use local variable to manage concurrency and increment BEFORE spinning up any agent

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,21 @@
+final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    disableConcurrentBuilds(abortPrevious: true),
+    pipelineTriggers([cron(cronExpr)]),
+])
+
 def agentSelector(String imageType) {
     // Linux agent
     if (imageType == 'linux') {
-        // Need Docker and a LOT of memory for faster builds (due to multi archs) or fallback to linux (trusted.ci)
-        return 'docker-highmem || linux'
+        // This function is defined in the jenkins-infra/pipeline-library
+        if (infra.isTrusted()) {
+            return 'linux'
+        } else {
+            // Need Docker and a LOT of memory for faster builds (due to multi archs) or fallback to linux (trusted.ci)
+            return 'docker-highmem'
+        }
     }
     // Windows Server Core 2022 agent
     if (imageType.contains('2022')) {
@@ -12,93 +25,81 @@ def agentSelector(String imageType) {
     return 'windows-2019'
 }
 
-pipeline {
-    agent none
-
-    options {
-        buildDiscarder(logRotator(daysToKeepStr: '10'))
+// Ref. https://github.com/jenkins-infra/pipeline-library/pull/917
+def spotAgentSelector(String agentLabel, int counter) {
+    if (counter > 1) {
+        return agentLabel + ' && nonspot'
     }
 
-    stages {
-        stage('Pipeline') {
-            matrix {
-                axes {
-                    axis {
-                        name 'IMAGE_TYPE'
-                        values 'linux', 'nanoserver-1809', 'nanoserver-ltsc2019', 'nanoserver-ltsc2022', 'windowsservercore-1809', 'windowsservercore-ltsc2019', 'windowsservercore-ltsc2022'
-                    }
-                }
-                stages {
-                    stage('Main') {
-                        agent {
-                            label agentSelector(env.IMAGE_TYPE)
-                        }
-                        options {
-                            timeout(time: 60, unit: 'MINUTES')
-                        }
-                        environment {
-                            REGISTRY_ORG = "${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
-                        }
-                        stages {
+    return agentLabel + ' && spot'
+}
+
+// Specify parallel stages
+parallelStages = [failFast: false]
+[
+    'linux',
+    'nanoserver-1809',
+    'nanoserver-ltsc2019',
+    'nanoserver-ltsc2022',
+    'windowsservercore-1809',
+    'windowsservercore-ltsc2019',
+    'windowsservercore-ltsc2022'
+].each { imageType ->
+    parallelStages["Building ${imageType}"] = {
+        withEnv(["IMAGE_TYPE=${imageType}"]) {
+            int retryCounter = 0
+            retry(count: 2, conditions: [kubernetesAgent(handleNonKubernetes: true), nonresumable()]) {
+                // Use local variable to manage concurrency and increment BEFORE spinning up any agent
+                final String resolvedAgentLabel = spotAgentSelector(agentSelector(imageType), retryCounter)
+                retryCounter++
+                node(resolvedAgentLabel) {
+                    timeout(time: 60, unit: 'MINUTES') {
+                        if (imageType == "linux") {
                             stage('Prepare Docker') {
-                                when {
-                                    environment name: 'IMAGE_TYPE', value: 'linux'
-                                }
-                                steps {
-                                    sh 'make docker-init'
-                                }
+                                sh 'make docker-init'
                             }
-                            stage('Build and Test') {
-                                // This stage is the "CI" and should be run on all code changes triggered by a code change
-                                when {
-                                    not { buildingTag() }
-                                }
-                                steps {
-                                    script {
-                                        if (isUnix()) {
-                                            sh './build.sh'
-                                            sh './build.sh test'
-                                            // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
-                                            sh 'make every-build'
-                                        } else {
-                                            powershell '& ./build.ps1 test'
-                                        }
-                                    }
-                                }
-                                post {
-                                    always {
-                                        archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
-                                        junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results*.xml')
-                                    }
-                                }
-                            }
+                        }
+                        // This function is defined in the jenkins-infra/pipeline-library
+                        if (infra.isTrusted()) {
+                            // trusted.ci.jenkins.io builds (e.g. publication to DockerHub)
                             stage('Deploy to DockerHub') {
-                                // This stage is the "CD" and should only be run when a tag triggered the build
-                                when {
-                                    buildingTag()
-                                }
-                                steps {
-                                    script {
-                                        def tagItems = env.TAG_NAME.split('-')
-                                        if(tagItems.length == 2) {
-                                            withEnv([
-                                                "ON_TAG=true",
-                                                "REMOTING_VERSION=${tagItems[0]}",
-                                                "BUILD_NUMBER=${tagItems[1]}",
-                                            ]) {
-                                                // This function is defined in the jenkins-infra/pipeline-library
-                                                infra.withDockerCredentials {
-                                                    if (isUnix()) {
-                                                        sh 'make publish'
-                                                    } else {
-                                                        powershell '& ./build.ps1 publish'
-                                                    }
-                                                }
+                                String[] tagItems = env.TAG_NAME.split('-')
+                                if(tagItems.length == 2) {
+                                    withEnv([
+                                        "ON_TAG=true",
+                                        "REMOTING_VERSION=${tagItems[0]}",
+                                        "BUILD_NUMBER=${tagItems[1]}",
+                                    ]) {
+                                        // This function is defined in the jenkins-infra/pipeline-library
+                                        infra.withDockerCredentials {
+                                            if (isUnix()) {
+                                                sh 'make publish'
+                                            } else {
+                                                powershell '& ./build.ps1 publish'
                                             }
-                                        } else {
-                                            error("The deployment to Docker Hub failed because the tag doesn't contain any '-'.")
                                         }
                                     }
+                                } else {
+                                    error("The deployment to Docker Hub failed because the tag doesn't contain any '-'.")
+                                }
+                            }
+                        } else {
+                            stage('Build and Test') {
+                                // ci.jenkins.io builds (e.g. no publication)
+                                if (isUnix()) {
+                                    sh './build.sh'
+                                    sh './build.sh test'
+                                } else {
+                                    powershell '& ./build.ps1 test'
+                                    archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
+                                }
+                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results*.xml')
+                            }
+                            // If the tests are passing for Linux AMD64, then we can build all the CPU architectures
+                            if (isUnix()) {
+                                stage('Multi-Arch Build') {
+
+                                    sh 'make every-build'
                                 }
                             }
                         }
@@ -109,4 +110,6 @@ pipeline {
     }
 }
 
-// vim: ft=groovy
+// Execute parallel stages
+parallel parallelStages
+// // vim: ft=groovy


### PR DESCRIPTION
This PR changes the pipeline to support the new infrastructure agent labels pattern on ci.jenkins.io (ref. https://github.com/jenkins-infra/helpdesk/issues/4598 and https://github.com/jenkins-infra/pipeline-library/pull/917).

- Switch to scripted syntax to support the `retry()` with counter and agent failure detection (see the note below)
- Ensure that `trusted.ci.jenkins.io` Linux VM agent labels are not used on ci.jenkins.io which result in failed build due to CPU mismatch on ci.jenkins.io (since the `linux` label is too generic)

(edit) NOTE: The label `docker-highmem` is now using Spot instances (ref. https://github.com/jenkins-infra/helpdesk/issues/4598). In the current state (even with #961).
If the spot agent is reclaimed, the build fails on ci.jenkins.io.

This PR is about retrying the build, on ci.jenkins.io, when the underlying agent is failing (spot reclaimed, deletion by the infra team, cloud failure, etc.).

It requires the agent label to change during the pipeline execution which is not possible using the declarative syntax, as it is parses the (static) `agent` block directive at the beginning.
Also, even if `retry` can be specified to the `options` with the proposed argument, it does not provide a dynamic counter.
=> these 2 reasons explains why a shift to scripted is needed.

----

Given the discussion (which I did not anticipated) towards scripted vs. declarative, it means we have to decide if we want the pipeline to:

- Retry if agent failure is detected, but with the same label (e.g. again with spot). But we can keep declarative.
- Or go toward my proposal and switch to scripted.
- Or eventually find a solution (and dismiss my arguments) to fallback to `nonspot` as part of the pipeline.
----

In the future, we might want to provide an `infra.withNode()` in the jenkins-infra/pipeline-library to provide an higher order of abstraction (encapsulating retries, spot selections, etc.)