### PR TITLE
chore(Jenkinsfile) avoid using trusted.ci agent labels on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,13 @@
 def agentSelector(String imageType) {
     // Linux agent
     if (imageType == 'linux') {
-        // Need Docker and a LOT of memory for faster builds (due to multi archs) or fallback to linux (trusted.ci)
-        return 'docker-highmem || linux'
+        // This function is defined in the jenkins-infra/pipeline-library
+        if (infra.isTrusted()) {
+            return 'linux'
+        } else {
+            // Need Docker and a LOT of memory for faster builds (due to multi archs) or fallback to linux (trusted.ci)
+            return 'docker-highmem'
+        }
     }
     // Windows Server Core 2022 agent
     if (imageType.contains('2022')) {


### PR DESCRIPTION
If the label `docker-highmem` label does not provide any agent on ci.jenkins.io, we don't want it to fall back on `linux` label, because it may lead to spinning up an arm64 machine which fails the build

Extracted from https://github.com/jenkinsci/docker-agent/pull/960 to provide a short term fix to failing builds, unrelated to the support of spot/retries
