### PR TITLE
chore(Jenkinsfile) correct potential memory leak in the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ def spotAgentSelector(String agentLabel, int counter) {
 }
 
 // Specify parallel stages
-parallelStages = [failFast: false]
+def parallelStages = [failFast: false]
 [
     'linux',
     'nanoserver-1809',


### PR DESCRIPTION
Removes the message

```
Did you forget the `def` keyword? WorkflowScript seems to be setting a field named parallelStages (to a value of type LinkedHashMap) which could lead to memory leaks or other issues.
```

Caused by #960
