### PR TITLE
chore: fix warnings from buildx checks (`FromAsCasing` and `LegacyKeyValueFormat`)

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 ARG DEBIAN_RELEASE=bookworm-20250317
-FROM debian:"${DEBIAN_RELEASE}"-slim as jre-build
+FROM debian:"${DEBIAN_RELEASE}"-slim AS jre-build
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
@@ -101,7 +101,7 @@ ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins
 RUN chmod 0644 /usr/share/jenkins/agent.jar \
   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=jre-build /javaruntime "$JAVA_HOME"

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -65,7 +65,7 @@ ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins
 RUN chmod 0644 /usr/share/jenkins/agent.jar \
     && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=jre-build /javaruntime "$JAVA_HOME"


### PR DESCRIPTION
While working on #960 , I saw a set of warning messages in the logs which made me learn there is new feature in the Docker build (with buildx) commands: a syntax checker \o/

Ref. https://docs.docker.com/build/checks/#check-a-build-without-building

This PR make a few minor changes following the recommendations from these messages to remove the warnings.

We can run the checks without building using the command `docker buildx bake --file docker-bake.hcl --check linux` on Linux, and `docker buildx bake --file docker-bake.hcl --check windows` on Windows.
