### PR TITLE
Bump UBI9 version to 9.5-1745848351

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -105,7 +105,7 @@ variable "DEBIAN_RELEASE" {
 }
 
 variable "UBI9_TAG" {
-  default = "9.5-1744101466"
+  default = "9.5-1745848351"
 }
 
 # Set this value to a specific Windows version to override Windows versions to build returned by windowsversions function

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -1,4 +1,4 @@
-ARG UBI9_TAG=9.5-1744101466
+ARG UBI9_TAG=9.5-1745848351
 FROM registry.access.redhat.com/ubi9/ubi:"${UBI9_TAG}" AS jre-build
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -36,8 +36,8 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
   exit 1
 fi
 
-# Parse the JSON response using jq to find the version associated with the "latest" tag
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | xargs)
+# Parse the JSON response using jq to find the most recent version
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name != "latest") | .tags[] | .name ' | sort -u | tail -n 1)
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then


### PR DESCRIPTION
## Bump UBI9 version to 9.5-1744101466

The updatecli process is failing due to some change in the UBI 9 API response.  Rather than delay the availability of remoting 3309 and the latest operating system updates, I've created the updates myself.

Includes a change that needs to be reviewed by those who understand updatecli better than I do.  @gounthar or @dduportal or @lemeurherveCB would be great to review that proposed change.  The change works, but I am not confident that it is correct.

### Testing done

Confirmed that `make build` and `make clean` are both successful.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
