### PR TITLE
Bump the Jenkins remoting version to 3309.v27b_9314fd1a_4

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -86,7 +86,7 @@ RUN apk add --no-cache \
       tzdata-utils \
     && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
-ARG VERSION=3307.v632ed11b_3a_c7
+ARG VERSION=3309.v27b_9314fd1a_4
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
 RUN chmod 0644 /usr/share/jenkins/agent.jar \
   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar

--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,7 @@ Param(
     # Default build.ps1 target
     [String] $Target = 'build',
     # Remoting version to include
-    [String] $RemotingVersion = '3307.v632ed11b_3a_c7',
+    [String] $RemotingVersion = '3309.v27b_9314fd1a_4',
     # Type of agent ("agent" or "inbound-agent")
     [String] $AgentType = '',
     # Windows flavor and windows version to build

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ OPTIND=1
 
 target="build"
 build_number="1"
-remoting_version="3307.v632ed11b_3a_c7"
+remoting_version="3309.v27b_9314fd1a_4"
 exit_result=0
 
 function exit_if_error() {

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -96,7 +96,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /tmp/* /var/cache/* /var/lib/apt/lists/*
 
-ARG VERSION=3307.v632ed11b_3a_c7
+ARG VERSION=3309.v27b_9314fd1a_4
 ADD --chown="${user}":"${group}" "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar" /usr/share/jenkins/agent.jar
 RUN chmod 0644 /usr/share/jenkins/agent.jar \
   && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -65,7 +65,7 @@ variable "JAVA21_VERSION" {
 }
 
 variable "REMOTING_VERSION" {
-  default = "3307.v632ed11b_3a_c7"
+  default = "3309.v27b_9314fd1a_4"
 }
 
 variable "REGISTRY" {

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -36,8 +36,8 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
   exit 1
 fi
 
-# Parse the JSON response using jq to find the version associated with the "latest" tag
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | xargs)
+# Parse the JSON response using jq to find the most recent version
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name != "latest") | .tags[] | .name ' | sort -u | tail -n 1)
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -100,7 +100,7 @@ ARG AGENT_WORKDIR=${AGENT_ROOT}/Work
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 # Get the Agent from the Jenkins Artifacts Repository
-ARG VERSION=3307.v632ed11b_3a_c7
+ARG VERSION=3309.v27b_9314fd1a_4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest $('https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/{0}/remoting-{0}.jar' -f $env:VERSION) -OutFile $(Join-Path C:/ProgramData/Jenkins $env:AGENT_FILENAME) -UseBasicParsing ; `
     Invoke-WebRequest $('https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/{0}/remoting-{0}.jar.sha1' -f $env:VERSION) -OutFile (Join-Path C:/ProgramData/Jenkins $env:AGENT_HASH_FILENAME) -UseBasicParsing ; `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -93,7 +93,7 @@ ARG AGENT_WORKDIR=${AGENT_ROOT}/Work
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}
 
 # Get the Agent from the Jenkins Artifacts Repository
-ARG VERSION=3307.v632ed11b_3a_c7
+ARG VERSION=3309.v27b_9314fd1a_4
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     Invoke-WebRequest $('https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/{0}/remoting-{0}.jar' -f $env:VERSION) -OutFile $(Join-Path C:/ProgramData/Jenkins $env:AGENT_FILENAME) -UseBasicParsing ; `
     Invoke-WebRequest $('https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/{0}/remoting-{0}.jar.sha1' -f $env:VERSION) -OutFile (Join-Path C:/ProgramData/Jenkins $env:AGENT_HASH_FILENAME) -UseBasicParsing ; `


### PR DESCRIPTION
## Bump the Jenkins remoting version to 3309.v27b_9314fd1a_4

The updatecli GitHub action is failing due to a change in the UBI-9 API output.  Rather than wrestle with adapting to the new API output, I created this pull request and two others to provide remoting 3309 in a new release of the agent container images.

### Testing done

Confirmed that `make build` and `make test` pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
