### PR TITLE
Update examples to use most recent JDK versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,29 +145,33 @@ $ make show
       "context": ".",
       "dockerfile": "alpine/Dockerfile",
       "args": {
-        "ALPINE_TAG": "3.20.3",
-        "JAVA_VERSION": "17.0.12_7",
-        "VERSION": "3261.v9c670a_4748a_9"
+        "ALPINE_TAG": "3.21.3",
+        "JAVA_VERSION": "17.0.15_6",
+        "VERSION": "3309.v27b_9314fd1a_4"
       },
       "tags": [
         "docker.io/jenkins/agent:alpine",
-        "docker.io/jenkins/agent:alpine3.20",
         "docker.io/jenkins/agent:latest-alpine",
-        "docker.io/jenkins/agent:latest-alpine3.20",
         "docker.io/jenkins/agent:alpine-jdk17",
-        "docker.io/jenkins/agent:alpine3.20-jdk17",
         "docker.io/jenkins/agent:latest-alpine-jdk17",
-        "docker.io/jenkins/agent:latest-alpine3.20-jdk17"
+        "docker.io/jenkins/agent:alpine3.21",
+        "docker.io/jenkins/agent:latest-alpine3.21",
+        "docker.io/jenkins/agent:alpine3.21-jdk17",
+        "docker.io/jenkins/agent:latest-alpine3.21-jdk17"
       ],
       "target": "agent",
       "platforms": [
         "linux/amd64"
       ],
       "output": [
-        "type=docker"
+        {
+          "type": "docker"
+        }
       ]
     },
     [...]
+  }
+}
 ```
 
 To view all tags, set `ON_TAG` (and eventually `BUILD_NUMBER`):
@@ -180,21 +184,21 @@ $ ON_TAG=true BUILD_NUMBER=3 make show
       "dockerfile": "alpine/Dockerfile",
       "args": {
         "ALPINE_TAG": "3.21.3",
-        "JAVA_VERSION": "17.0.14_7",
-        "VERSION": "3283.v92c105e0f819"
+        "JAVA_VERSION": "17.0.15_6",
+        "VERSION": "3309.v27b_9314fd1a_4"
       },
       "tags": [
-        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine-jdk17",
-        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21-jdk17",
-        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine",
-        "docker.io/jenkins/agent:3283.v92c105e0f819-3-alpine3.21",
+        "docker.io/jenkins/agent:3309.v27b_9314fd1a_4-3-alpine-jdk17",
+        "docker.io/jenkins/agent:3309.v27b_9314fd1a_4-3-alpine",
         "docker.io/jenkins/agent:alpine",
-        "docker.io/jenkins/agent:alpine3.21",
         "docker.io/jenkins/agent:latest-alpine",
-        "docker.io/jenkins/agent:latest-alpine3.21",
         "docker.io/jenkins/agent:alpine-jdk17",
-        "docker.io/jenkins/agent:alpine3.21-jdk17",
         "docker.io/jenkins/agent:latest-alpine-jdk17",
+        "docker.io/jenkins/agent:3309.v27b_9314fd1a_4-3-alpine3.21-jdk17",
+        "docker.io/jenkins/agent:3309.v27b_9314fd1a_4-3-alpine3.21",
+        "docker.io/jenkins/agent:alpine3.21",
+        "docker.io/jenkins/agent:latest-alpine3.21",
+        "docker.io/jenkins/agent:alpine3.21-jdk17",
         "docker.io/jenkins/agent:latest-alpine3.21-jdk17"
       ],
       [...]

--- a/build.ps1
+++ b/build.ps1
@@ -85,7 +85,7 @@ function Test-Image {
         [String] $AgentTypeAndImageName
     )
 
-    # Ex: agent|docker.io/jenkins/agent:jdk21-windowsservercore-ltsc2019|21.0.3_9
+    # Ex: agent|docker.io/jenkins/agent:jdk21-windowsservercore-ltsc2019|21.0.7_6
     $items = $AgentTypeAndImageName.Split('|')
     $agentType = $items[0]
     $imageName = $items[1] -replace 'docker.io/', ''

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETPLATFORM
 COPY adoptium-get-jdk-link.sh /usr/bin/local/adoptium-get-jdk-link.sh
 COPY adoptium-install-jdk.sh /usr/bin/local/adoptium-install-jdk.sh
 
-ARG JAVA_VERSION=17.0.12_7
+ARG JAVA_VERSION=17.0.15_6
 
 RUN dnf install --disableplugin=subscription-manager --setopt=install_weak_deps=0 --setopt=tsflags=nodocs --allowerasing -y \
     ca-certificates \

--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -36,8 +36,8 @@ if [ -z "$response" ] || [ "$response" == "null" ]; then
   exit 1
 fi
 
-# Parse the JSON response using jq to find the version associated with the "latest" tag
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | xargs)
+# Parse the JSON response using jq to find the most recent version
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name != "latest") | .tags[] | .name ' | sort -u | tail -n 1)
 
 # Check if the latest_tag is empty
 if [ -z "$latest_tag" ]; then

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -29,7 +29,7 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=17.0.10+7
+ARG JAVA_VERSION=17.0.15+6
 RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
     $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
     $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -29,7 +29,7 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=17.0.10+7
+ARG JAVA_VERSION=17.0.15+6
 RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
     $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
     $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('+', '%2B') ; `


### PR DESCRIPTION
## Update examples to use most recent JDK versions

Update examples to Java 17.0.15

Use 21.0.7_6 instead of 21.0.3_9 in example comment.

Includes a change that needs to be reviewed by those who understand updatecli better than I do.  @gounthar or @dduportal or @lemeurherveCB would be great to review that proposed change.  The change works, but I am not confident that it is correct.

### Testing done

Copied the example output from current output samples.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
