### PR TITLE
chore(GHA) run `updatecli` once a day

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -3,8 +3,7 @@ on:
   # Allow to be run manually
   workflow_dispatch:
   schedule:
-    # Run once per week (to avoid alert fatigue)
-    - cron: '0 2 * * 1' # Every Monday at 2am UTC
+    - cron: '0 1 * * *' # Once a day at 01:00am UTC
   push:
   pull_request:
 jobs:


### PR DESCRIPTION
Looking at #980 and #978 , it is another example of us, maintainers, expecting a dependency to be proposed for update in a bump PR while `updatecli` did not run.

In this particular case, there was a failure in one of the `updatecli` manifests (UBI9)  which created confusion.

This PR is a proposal to change the schedule of the `updatecli` GitHub Action job so it runs once a day instead of once a week to solve this confusion.