### PR TITLE
chore(updatecli): add missing targets to jdk17 manifest

### DIFF
--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -49,28 +49,30 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA17_VERSION.default
     scmid: default
-  setJDK17VersionAlpine:
-    name: "Bump JDK17 default ARG version on Alpine Dockerfile"
+  ## Update Dockerfiles default JAVA_VERSION argument as JDK17 is the current default Java version
+  setJDK17VersionLinux:
+    name: "Bump JDK17 default ARG version in Linux images"
     kind: dockerfile
     transformers:
       - replacer:
           from: "+"
           to: "_"
     spec:
-      file: alpine/Dockerfile
+      files:
+        - alpine/Dockerfile
+        - debian/Dockerfile
+        - rhel/ubi9/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-  setJDK17VersionDebian:
-    name: "Bump JDK17 default ARG version on Debian Dockerfile"
+  setJDK17VersionWindows:
+    name: "Bump JDK17 default ARG version in Windows images"
     kind: dockerfile
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
     spec:
-      file: debian/Dockerfile
+      files:
+        - windows/nanoserver/Dockerfile
+        - windows/windowsservercore/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION


### PR DESCRIPTION
This PR adds rhel-ubi9, nanoserver and windowservercore Dockerfiles as targets of jdk17.yaml updatecli manifest as they weren't covered cf https://github.com/jenkinsci/docker-agent/pull/981#discussion_r2075478448, https://github.com/jenkinsci/docker-agent/pull/981/files#diff-8279a2baaa897bfb70dbfa0bf71f3599f7713f5da5d0b46a483488f3a590ab9eR32 and https://github.com/jenkinsci/docker-agent/pull/981/files#diff-2e09df7c118a78a0a7de0a6fa97be765befeced7c51ca4258f0de01943b3e069R32

Follow-up of:
- https://github.com/jenkinsci/docker-agent/pull/981#discussion_r2075478448

### Testing done

```
updatecli diff --config updatecli/updatecli.d/jdk17.yaml --values updatecli/values.github-action.yaml
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
