### PR TITLE
doc: add `REMOTING_OPTS` optional env var and deprecate others in README

### DIFF
--- a/README_inbound-agent.md
+++ b/README_inbound-agent.md
@@ -62,6 +62,10 @@ Optional environment variables:
 * `JENKINS_JAVA_BIN`: Path to Java executable to use instead of the default in PATH or obtained from JAVA_HOME
 * `JENKINS_JAVA_OPTS` : Java Options to use for the remoting process, otherwise obtained from JAVA_OPTS, **Warning** :exclamation: For more information on Windows usage, please see the **Windows Jenkins Java Opts** [section below](#windows-jenkins-java-opts).
 * `JENKINS_AGENT_FILE` : Jenkins agent jar file location, `/usr/share/jenkins/agent.jar` will be used if this is not set
+* `REMOTING_OPTS` : Generic way to pass additional CLI options to agent.jar (see -help)
+
+Deprecated environment variables (prefer setting `REMOTING_OPTS`)
+
 * `JENKINS_URL`: url for the Jenkins server, can be used as a replacement to `-url` option, or to set alternate jenkins URL
 * `JENKINS_TUNNEL`: (`HOST:PORT`) connect to this agent host and port instead of Jenkins server, assuming this one do route TCP traffic to Jenkins controller. Useful when when Jenkins runs behind a load balancer, reverse proxy, etc.
 * `JENKINS_SECRET`: (use only if not set as an argument) the secret as shown on the controller after creating the agent


### PR DESCRIPTION
This PR adds `REMOTING_OPTS` to the optional environment variables and deprecate others in inbound agent README.

Follow-up of:
- #809

<!-- Please describe your pull request here. -->

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
