### PR TITLE
chore: Update Debian version from Bookworm to Trixie

### DIFF
--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump Debian Bookworm version
+name: Bump Debian Trixie version
 
 scms:
   default:
@@ -14,22 +14,22 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  bookwormLatestVersion:
+  trixieLatestVersion:
     kind: dockerimage
-    name: "Get the latest Debian Bookworm Linux version"
+    name: "Get the latest Debian trixie Linux version"
     spec:
       image: "debian"
-      tagfilter: "bookworm-*"
+      tagfilter: "trixie-*"
       versionfilter:
         kind: regex
         pattern: >-
-          bookworm-\d+$
+          trixie-\d+$
 
 targets:
   updateDockerfile:
     name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile"
     kind: dockerfile
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       file: debian/Dockerfile
       instruction:
@@ -39,7 +39,7 @@ targets:
   updateDockerBake:
     name: "Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl"
     kind: hcl
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       file: docker-bake.hcl
       path: variable.DEBIAN_RELEASE.default
@@ -49,8 +49,8 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Debian Bookworm Linux version to {{ source "bookwormLatestVersion" }}
+    title: Bump Debian trixie Linux version to {{ source "trixieLatestVersion" }}
     spec:
       labels:
         - dependencies
-        - debian-bookworm
+        - debian-trixie

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -53,4 +53,4 @@ actions:
     spec:
       labels:
         - dependencies
-        - debian-trixie
+        - debian


### PR DESCRIPTION
We received an automatic PR for Debian Bookworm in #1050, even though we've transitioned to Trixie. To align with this change, we need to update the updatecli manifest accordingly.

Closes #1050 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
