### PR TITLE
chore(updatecli): switch debian manifest from Bookworm to Trixie

### DIFF
--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump Debian Bookworm version
+name: Bump Debian Trixie version
 
 scms:
   default:
@@ -14,22 +14,22 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  bookwormLatestVersion:
+  trixieLatestVersion:
     kind: dockerimage
-    name: "Get the latest Debian Bookworm Linux version"
+    name: "Get the latest Debian Trixie Linux version"
     spec:
       image: "debian"
-      tagfilter: "bookworm-*"
+      tagfilter: "trixie-*"
       versionfilter:
         kind: regex
         pattern: >-
-          bookworm-\d+$
+          trixie-\d+$
 
 targets:
   updateDockerfile:
     name: "Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile"
     kind: dockerfile
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       file: debian/Dockerfile
       instruction:
@@ -39,7 +39,7 @@ targets:
   updateDockerBake:
     name: "Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl"
     kind: hcl
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       file: docker-bake.hcl
       path: variable.DEBIAN_RELEASE.default
@@ -49,8 +49,8 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Debian Bookworm Linux version to {{ source "bookwormLatestVersion" }}
+    title: Bump Debian Trixie Linux version to {{ source "trixieLatestVersion" }}
     spec:
       labels:
         - dependencies
-        - debian-bookworm
+        - debian


### PR DESCRIPTION
Follow-up of:
- #1036 

- Closes: #1050

### Testing done

```
$ updatecli diff --config ./updatecli/updatecli.d/debian.yaml --values ./updatecli/values.github-action.yaml
⚠ Bump Debian Trixie version:
        Source:
                ✔ [trixieLatestVersion] Get the latest Debian Trixie Linux version
        Target:
                ⚠ [updateDockerBake] Update the default value of the variable DEBIAN_RELEASE in the docker-bake.hcl
                ⚠ [updateDockerfile] Update the value of the base image (ARG DEBIAN_RELEASE) in the Dockerfile
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
