### PR TITLE
Set permission of home directory for debian based images

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -75,6 +75,7 @@ ARG gid=1000
 
 RUN groupadd -g "${gid}" "${group}" \
   && useradd -l -c "Jenkins user" -d /home/"${user}" -u "${uid}" -g "${gid}" -m "${user}" || echo "user ${user} already exists."
+  && chmod 755 /home/"${user}"
 
 ARG AGENT_WORKDIR=/home/"${user}"/agent
 ENV TZ=Etc/UTC


### PR DESCRIPTION
Change permission of home directory of user `jenkins`.

Fixes #1057 

### Testing done

* Image was built **without** the change

```text
jenkins@72d49922044d:~$ ls -la /home/jenkins/
total 12
drwx------ 1 jenkins jenkins   35 Sep 30 14:02 .
drwxr-xr-x 1 root    root      21 Sep 30 13:59 ..
-rw-r--r-- 1 jenkins jenkins  220 Jul 30 19:28 .bash_logout
-rw-r--r-- 1 jenkins jenkins 3526 Jul 30 19:28 .bashrc
drwxr-xr-x 2 jenkins jenkins    6 Sep 30 14:02 .jenkins
-rw-r--r-- 1 jenkins jenkins  807 Jul 30 19:28 .profile
drwxr-xr-x 2 jenkins jenkins    6 Sep 30 14:02 agent
```

* Image was built **with** the change

```text
jenkins@abab2b9a11df:~$ ls -la /home/jenkins/
total 12
drwxr-xr-x 1 jenkins jenkins   35 Sep 30 14:02 .
drwxr-xr-x 1 root    root      21 Sep 30 13:59 ..
-rw-r--r-- 1 jenkins jenkins  220 Jul 30 19:28 .bash_logout
-rw-r--r-- 1 jenkins jenkins 3526 Jul 30 19:28 .bashrc
drwxr-xr-x 2 jenkins jenkins    6 Sep 30 14:02 .jenkins
-rw-r--r-- 1 jenkins jenkins  807 Jul 30 19:28 .profile
drwxr-xr-x 2 jenkins jenkins    6 Sep 30 14:02 agent
```

Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
