### PR TITLE
Use Trixie in the Debian container name, not Bookworm

### DIFF
--- a/README_agent.md
+++ b/README_agent.md
@@ -52,12 +52,12 @@ The image has several supported configurations, which can be accessed via the fo
 
 * Linux Images:
   * Java 17 (default):
-    * `jenkins/agent:latest`: Based on `debian:bookworm-${builddate}`
+    * `jenkins/agent:latest`: Based on `debian:trixie-${builddate}`
       * Also tagged as: 
         * `jenkins/agent:jdk17`
-        * `jenkins/agent:bookworm-jdk17`
-        * `jenkins/agent:latest-bookworm`
-        * `jenkins/agent:latest-bookworm-jdk17`
+        * `jenkins/agent:trixie-jdk17`
+        * `jenkins/agent:latest-trixie`
+        * `jenkins/agent:latest-trixie-jdk17`
         * `jenkins/agent:latest-jdk17`
     * alpine (Small image based on Alpine Linux, based on `alpine:${version}`):
       * `jenkins/agent:jenkins/agent:alpine` 
@@ -70,11 +70,11 @@ The image has several supported configurations, which can be accessed via the fo
       * `jenkins/agent:latest-rhel-ubi9`
       * `jenkins/agent:latest-rhel-ubi9-jdk17`
   * Java 21:
-    * bookworm (Based on `debian:bookworm-${builddate}`):
-      * `jenkins/agent:bookworm`
-      * `jenkins/agent:bookworm-jdk21`
+    * trixie (Based on `debian:trixie-${builddate}`):
+      * `jenkins/agent:trixie`
+      * `jenkins/agent:trixie-jdk21`
       * `jenkins/agent:jdk21`
-      * `jenkins/agent:latest-bookworm-jdk21`
+      * `jenkins/agent:latest-trixie-jdk21`
     * alpine (Small image based on Alpine Linux, based on `alpine:${version}`):
       * `jenkins/agent:alpine` 
       * `jenkins/agent:alpine-jdk21`

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -230,7 +230,7 @@ function distribution_suffix {
 function distribution_name {
   params = [distribution]
   result = (equal("debian", distribution)
-    ? "bookworm"
+    ? "trixie"
   : distribution)
 }
 
@@ -256,7 +256,7 @@ function "linux_tags" {
     # If the jdk is the default one, add distribution and latest short tags
     is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:${distribution_name(distribution)}" : "",
     is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest${distribution_suffix(distribution)}" : "",
-    # Needed for the ":latest-bookworm" case. For other distributions, result in the same tag as above (not an issue, deduplicated at the end)
+    # Needed for the ":latest-trixie" case. For other distributions, result in the same tag as above (not an issue, deduplicated at the end)
     is_default_jdk(jdk) ? "${REGISTRY}/${orgrepo(type)}:latest-${distribution_name(distribution)}" : "",
 
     # Tags always added


### PR DESCRIPTION
## Use Trixie in the Debian container name, not Bookworm

Fixes https://github.com/jenkinsci/docker-agent/issues/1059 by using "trixie" in the container image name instead of "bookworm".

Amends pull request:

* https://github.com/jenkinsci/docker-agent/pull/1051

### Testing done

Confirmed that generated container image names now look like this:

```
REPOSITORY              TAG                           IMAGE ID
jenkins/inbound-agent   jdk21                         ff4ddd1974c9
jenkins/inbound-agent   latest-jdk21                  ff4ddd1974c9
jenkins/inbound-agent   latest-trixie-jdk21           ff4ddd1974c9
jenkins/inbound-agent   trixie-jdk21                  ff4ddd1974c9
jenkins/inbound-agent   jdk17                         28bcb4477386
jenkins/inbound-agent   latest                        28bcb4477386
jenkins/inbound-agent   latest-jdk17                  28bcb4477386
jenkins/inbound-agent   latest-trixie                 28bcb4477386
jenkins/inbound-agent   latest-trixie-jdk17           28bcb4477386
jenkins/inbound-agent   trixie                        28bcb4477386
jenkins/inbound-agent   trixie-jdk17                  28bcb4477386
jenkins/agent           jdk25-preview                 6bfeae9538ab
jenkins/agent           latest-jdk25-preview          6bfeae9538ab
jenkins/agent           latest-trixie-jdk25-preview   6bfeae9538ab
jenkins/agent           trixie-jdk25-preview          6bfeae9538ab
jenkins/agent           jdk21                         fbce0191ee20
jenkins/agent           latest-jdk21                  fbce0191ee20
jenkins/agent           latest-trixie-jdk21           fbce0191ee20
jenkins/agent           trixie-jdk21                  fbce0191ee20
jenkins/agent           jdk17                         f2ea8ffec1ab
jenkins/agent           latest                        f2ea8ffec1ab
jenkins/agent           latest-jdk17                  f2ea8ffec1ab
jenkins/agent           latest-trixie                 f2ea8ffec1ab
jenkins/agent           latest-trixie-jdk17           f2ea8ffec1ab
jenkins/agent           trixie                        f2ea8ffec1ab
jenkins/agent           trixie-jdk17                  f2ea8ffec1ab
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
