### PR TITLE
Java 25 is not preview anymore

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -59,7 +59,7 @@ variable "default_jdk" {
 }
 
 variable "jdks_in_preview" {
-  default = [25]
+  default = []
 }
 
 variable "JAVA17_VERSION" {
@@ -71,7 +71,7 @@ variable "JAVA21_VERSION" {
 }
 
 variable "JAVA25_VERSION" {
-  default = "25+9-ea-beta"
+  default = "25+36"
 }
 
 variable "REMOTING_VERSION" {


### PR DESCRIPTION
### Testing done

None (I have only podman on current machine, cannot use buildx).

Also https://github.com/jenkinsci/docker-agent/pull/1045 looks wrong

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

