### PR TITLE
chore(adoptium-install-jdk): don't try to move JDK folder if already at the correct place

### DIFF
--- a/adoptium-install-jdk.sh
+++ b/adoptium-install-jdk.sh
@@ -43,9 +43,11 @@ fi
 EXTRACTED_DIR=$(tar -tzf /tmp/jdk.tar.gz | head -n 1 | cut -f1 -d"/")
 
 # Rename the extracted directory to /opt/jdk-${JAVA_VERSION}
-if ! mv "/opt/${EXTRACTED_DIR}" "/opt/jdk-${JAVA_VERSION}"; then
-    echo "Error: Failed to rename the extracted directory. Exiting with status 1." >&2
-    exit 1
+if [ "${EXTRACTED_DIR}" != "jdk-${JAVA_VERSION}" ]; then
+    if ! mv "/opt/${EXTRACTED_DIR}" "/opt/jdk-${JAVA_VERSION}"; then
+        echo "Error: Failed to rename the extracted directory. Exiting with status 1." >&2
+        exit 1
+    fi
 fi
 
 # Remove the downloaded archive


### PR DESCRIPTION
This PR fixes the error noticed in #1061 when the JDK version contains a `+` and not a `_`.

Ref:
- https://github.com/jenkinsci/docker-agent/pull/1061#issuecomment-3359849628

### Testing done

Set a JDK25 version containing a `+` in docker-bake.hcl:
```diff
diff --git a/docker-bake.hcl b/docker-bake.hcl
index 45a1d95..f155497 100644
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -71,7 +71,7 @@ variable "JAVA21_VERSION" {
 }
 
 variable "JAVA25_VERSION" {
-  default = "25+9-ea-beta"
+  default = "25+36"
 }
```
Then `make build-agent_debian_jdk25`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
