### PR TITLE
chore: use bats junit formatter only in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,12 @@ test-%: prepare-test
 	@echo "== testing $*"
 	set -x
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
+ifeq ($(CI), true)
+# Execute the test harness and write result to a TAP file
 	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
+else
+	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags)
+endif
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done


### PR DESCRIPTION
This PR removes the junit formatter and result storage when executing `make test` locally (as `$CI` is set to `true` by Jenkins when running on CI), for a better contributor experience:
- Colored output
- No XML markup
- Test results displayed one after one instead of hanging until all tests passed
- Possibility to cancel the running tests while still seing the first results (currently return `printf: write error: Broken pipe` on cancel)

Similar to:
- https://github.com/jenkinsci/docker/pull/2088

<details><summary>Screenshots from the other PR</summary>

Before:
<img width="2147" height="683" alt="image" src="https://github.com/user-attachments/assets/c783a90f-a6d1-4714-a344-9b5afe8f224d" />

After:
<img width="2117" height="1062" alt="image" src="https://github.com/user-attachments/assets/6664d8a2-5713-4ed2-8438-83671e8cdd91" />

</details>

### Testing done

`make test` + CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
