### PR TITLE
chore(updatecli): update `git-lfs` manifest to also target Linux Dockerfiles and tests

### DIFF
--- a/updatecli/updatecli.d/git-lfs.yaml
+++ b/updatecli/updatecli.d/git-lfs.yaml
@@ -1,4 +1,4 @@
-name: Bump `git-lfs` version on Windows
+name: Bump `git-lfs` version
 
 scms:
   default:
@@ -15,7 +15,7 @@ scms:
 sources:
   lastVersion:
     kind: githubrelease
-    name: Get the latest `git-lfs` version
+    name: Get latest `git-lfs` version
     spec:
       owner: git-lfs
       repository: git-lfs
@@ -27,26 +27,32 @@ sources:
       - trimprefix: "v"
 
 targets:
-  setGitLfsVersionWindowsNanoserver:
-    name: Update the `git-lfs` Windows version for Windows Nanoserver
+  setGitLfsVersion:
+    name: Update `git-lfs` version in Dockerfiles
     kind: dockerfile
     spec:
-      file: windows/nanoserver/Dockerfile
+      files:
+        - alpine/Dockerfile
+        - debian/Dockerfile
+        - rhel/ubi9/Dockerfile
+        - windows/nanoserver/Dockerfile
+        - windows/windowsservercore/Dockerfile
       instruction:
         keyword: ARG
         matcher: GIT_LFS_VERSION
     scmid: default
-  setGitLfsVersionWindowsServer:
-    name: Update the `git-lfs` Windows version for Windows Core Server
-    kind: dockerfile
+  setGitLfsVersionLinuxTests:
+    name: Update `git-lfs` version in Linux tests
+    kind: file
     spec:
-      file: windows/windowsservercore/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: GIT_LFS_VERSION
+      file: tests/tests_agent.bats
+      matchpattern: >
+        GIT_LFS_VERSION=(.*)
+      replacepattern: >
+        GIT_LFS_VERSION='{{ source "lastVersion" }}'
     scmid: default
-  setGitLfsVersionTests:
-    name: Update the `git-lfs` Windows version in tests
+  setGitLfsVersionWindowsTests:
+    name: Update `git-lfs` version in Windows tests
     kind: file
     spec:
       file: tests/agent.Tests.ps1
@@ -59,10 +65,9 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump `git-lfs` version on Windows to {{ source "lastVersion" }}
+    title: Bump `git-lfs` version to {{ source "lastVersion" }}
     scmid: default
     spec:
       labels:
         - enhancement
         - git-lfs
-        - windows


### PR DESCRIPTION
This PR updates `git-lfs` manifest to also update Linux Dockerfiles and tests.

Follow-up of:
- #1009 

### Testing done
```
$ updatecli diff --config ./updatecli/updatecli.d/git-lfs.yaml --values ./updatecli/values.github-action.yaml
SUMMARY:



⚠ Bump `git-lfs` version:
        Source:
                ✔ [lastVersion] Get latest `git-lfs` version
        Target:
                ⚠ [setGitLfsVersion] Update `git-lfs` version in Dockerfiles
                ⚠ [setGitLfsVersionLinuxTests] Update `git-lfs` version in Linux tests
                ⚠ [setGitLfsVersionWindowsTests] Update `git-lfs` version in Windows tests


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
