### PR TITLE
chore(tests): check `git lfs env` instead of `git lfs version`

### DIFF
--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -83,9 +83,12 @@ Describe "[$global:IMAGE_NAME] image has correct applications in the PATH" {
     }
 
     It 'has git-lfs (and thus git) installed' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs version`""
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "exec $global:CONTAINERNAME $global:CONTAINERSHELL -C `"`& git lfs env`""
         $exitCode | Should -Be 0
-        $stdout.Trim() | Should -Match "git-lfs/${global:GITLFSVERSION}"
+        $r = [regex] "^git-lfs/(?<version>\d+\.\d+\.\d+)"
+        $m = $r.Match($stdout)
+        $m | Should -Not -Be $null
+        $m.Groups['version'].ToString() | Should -Be "$global:GITLFSVERSION"
     }
 
     It 'does not include jenkins-agent.ps1 (inbound-agent)' {

--- a/tests/tests_agent.bats
+++ b/tests/tests_agent.bats
@@ -63,7 +63,7 @@ GIT_LFS_VERSION='3.7.1'
 
   run docker exec "${cid}" sh -c "command -v git"
   assert_success
-  run docker exec "${cid}" git lfs version
+  run docker exec "${cid}" git lfs env
   assert_output --partial "${GIT_LFS_VERSION}"
 
   run docker exec "${cid}" sh -c "printenv | grep AGENT_WORKDIR"


### PR DESCRIPTION
This PR replaces `git lfs version` test by `git lfs env`, a bit more robust.

Follow-up of:
- #1009

Ref:
- https://github.com/jenkinsci/docker-agent/issues/1008#issuecomment-3421364701
- https://github.com/jenkinsci/docker-agent/pull/1009#pullrequestreview-3349235380

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
