### PR TITLE
chore(updatecli): also include Windows in JDK25 manifest

### DIFF
--- a/updatecli/updatecli.d/jdk25.yaml
+++ b/updatecli/updatecli.d/jdk25.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump JDK25 version for all Linux images
+name: Bump JDK25 version
 
 scms:
   default:
@@ -34,7 +34,7 @@ sources:
 # Architectures must match those of the targets in docker-bake.hcl
 conditions:
   checkTemurinAllReleases:
-    name: Check if the "<latestJDK25Version>" is available for all Linux platforms
+    name: Check if the "<latestJDK25Version>" is available for all platforms
     kind: temurin
     sourceid: latestJDK25Version
     spec:
@@ -46,10 +46,11 @@ conditions:
         - linux/aarch64
         - linux/ppc64le
         - linux/s390x
+        - windows/x64
 
 targets:
   setJDK25VersionDockerBake:
-    name: "Bump JDK25 version for Linux images in the docker-bake.hcl file"
+    name: "Bump JDK25 version in the docker-bake.hcl file"
     kind: hcl
     transformers:
       - replacer:
@@ -64,7 +65,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK25 version on Linux to {{ source "latestJDK25Version" }}
+    title: Bump JDK25 version to {{ source "latestJDK25Version" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
This PR ensures Windows platform is also checked in JDK25 updatecli manifest, and updates resulting PR title.

Follow-up of:
- https://github.com/jenkinsci/docker-agent/pull/1067

Refs:
- https://github.com/jenkinsci/docker-agent/pull/1087
  - Release notes manually updated in https://github.com/jenkinsci/docker-agent/releases/tag/3345.v03dee9b_f88fc-4

### Testing done

```
updatecli diff --config ./updatecli/updatecli.d/jdk25.yaml --values updatecli/values.github-action.yaml 
```

<details><summary>Output</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/jdk25.yaml"

SCM repository retrieved: 2


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



######################
# BUMP JDK25 VERSION #
######################

source: source#latestJDK25Version
-------------------------
✔ [temurin] found version "jdk-25.0.1+8"
[transformers]
✔ Result correctly transformed from "jdk-25.0.1+8" to "25.0.1+8"

condition: condition#checkTemurinAllReleases
---------------------------------
[temurin] using specific version (`spec.SpecificVersion`) from source value "25.0.1+8". Set `disablesourceinput` to true to avoid this behavior.
✔ (Platform "alpine-linux/x64") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "alpine-linux/aarch64") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "linux/x64") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "linux/aarch64") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "linux/ppc64le") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "linux/s390x") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ (Platform "windows/x64") Found release "jdk-25.0.1+8" which maps specified "25.0.1+8" version.
✔ All releases found.

target: target#setJDK25VersionDockerBake
--------------------------------
[transformers]
✔ Result correctly transformed from "25.0.1+8" to "25.0.1_8"

**Dry Run enabled**

✔ - no changes detected:
        path "variable.JAVA25_VERSION.default" already set to "25.0.1_8", from file "docker-bake.hcl"
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
