### PR TITLE
Install `git-lfs` config to system rather than global (#1109)

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -94,6 +94,7 @@ RUN arch=$(uname -m | sed -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g') \
   && curl -L -s -o git-lfs.tgz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${arch}-v${GIT_LFS_VERSION}.tar.gz" \
   && tar xzf git-lfs.tgz \
   && bash git-lfs-*/install.sh \
+  && git lfs install --skip-repo --system \
   && rm -rf git-lfs*
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -104,6 +104,7 @@ RUN arch=$(uname -m | sed -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g' -e 's/arm
   && curl -L -s -o git-lfs.tgz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${arch}-v${GIT_LFS_VERSION}.tar.gz" \
   && tar xzf git-lfs.tgz \
   && bash git-lfs-*/install.sh \
+  && git lfs install --skip-repo --system \
   && rm -rf git-lfs*
 
 ENV LANG=C.UTF-8

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -68,6 +68,7 @@ RUN arch=$(uname -m | sed -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g') \
   && curl -L -s -o git-lfs.tgz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${arch}-v${GIT_LFS_VERSION}.tar.gz" \
   && tar xzf git-lfs.tgz \
   && bash git-lfs-*/install.sh \
+  && git lfs install --skip-repo --system \
   && rm -rf git-lfs*
 
 ENV LANG=C.UTF-8

--- a/tests/tests_agent.bats
+++ b/tests/tests_agent.bats
@@ -65,6 +65,7 @@ GIT_LFS_VERSION='3.7.1'
   assert_success
   run docker exec "${cid}" git lfs env
   assert_output --partial "${GIT_LFS_VERSION}"
+  refute_output --regexp 'git config filter\.lfs\.\w+ = ""'
 
   run docker exec "${cid}" sh -c "printenv | grep AGENT_WORKDIR"
   assert_equal "${output}" "AGENT_WORKDIR=/home/jenkins/agent"


### PR DESCRIPTION
Fixes #1109, which restores behavior unintentionally changed in #1009.

The upstream install script installs the config globally (scoped to the user).  It is run as root, thus installed to `/root/.gitconfig` and unavailable to the jenkins user.  Installing to the system, as distro packages do, makes the config available to any user (i.e. jenkins).

The script currently has no way to change the scope or to opt out of the installation.  The global config could be safely removed to save a few bytes, but opting for a slightly shorter Dockerfile instead.

<!-- Please describe your pull request here. -->

### Testing done

The existing test case was updated to verify that no LFS filters had an empty configuration.  Prior to the fix, the test failed as expected.  After the fix, the test passed.

As well, our own internal test automation (not part of this PR) was modified to include a repo using LFS (`large.json` below) and an LFS server, building a job including these checks:
```groovy
// Jenkinsfile
      sh '''
set -eux
// <snip other tests>
# when installed properly, should have something like
#   git config filter.lfs.process = "git-lfs filter-process"
#   git config filter.lfs.smudge = "git-lfs smudge -- %f"
#   git config filter.lfs.clean = "git-lfs clean -- %f"
#
# if the binary is present but not installed, the values will be ""
git lfs env | grep -E '^git config filter\\.lfs\\.\\w+?\\s*=\\s*"git-lfs'
jq '.' large.json
'''
```
Prior to the fix, both would fail (an `|| true` was temporarily added to the first to allow the second command to fail):
```
+ git lfs env
+ grep -E '^git config filter\.lfs\.\w+?\s*=\s*"git-lfs'
+ true
+ jq . large.json
jq: parse error: Invalid numeric literal at line 1, column 8
```
After the fix, both succeed:
```
+ git lfs env
+ grep -E '^git config filter\.lfs\.\w+?\s*=\s*"git-lfs'
git config filter.lfs.process = "git-lfs filter-process"
git config filter.lfs.smudge = "git-lfs smudge -- %f"
git config filter.lfs.clean = "git-lfs clean -- %f"
+ jq . large.json
{
  "message": "j/k, I'm not really that big"
}
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

---

This same behavior changed would have occurred in https://github.com/jenkinsci/docker-ssh-agent/pull/557, but I have not actually validated it myself.  Same with https://github.com/jenkinsci/docker/pull/1954, though that was done over a year ago, so may not be important.  However, that change was _not_ made to the alpine images, probably because the motivation for the change was not the same as for these agents.
