### PR TITLE
Add jdk.net module for Java 25

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -44,7 +44,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se,jdk.net" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -49,7 +49,7 @@ RUN if [[ "${TARGETPLATFORM}" != "linux/arm/v7" ]]; then \
     case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se,jdk.net" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se,jdk.net" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \


### PR DESCRIPTION
Add jdk.net module for Java 25

I cannot confirm it will fix one of the issue I discovered running Jenkins on Java 25

```
[16:25:10.392+01:00] - java.lang.ExceptionInInitializerError: Exception java.lang.NoClassDefFoundError: jdk/net/Sockets [in thread "samples-ci-dotnet-core-main-225-sxrcq-djzx4-w70wq [#11] for JNLP4-connect connection to elca-jenkins-agent/172.30.70.87:50000 id=2054"]
[16:25:10.392+01:00] - 	at PluginClassLoader for apache-httpcomponents-client-5-api//org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.<clinit>(DefaultHttpClientConnectionOperator.java:87)
```

### Testing done

None. I cannot confirm it will resolve the issue.

But I will certainly test in on my test environment and iterate if needed

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
