### PR TITLE
fix: don't use `jlink` in JDK25 linux images for now

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,10 +41,17 @@ RUN apk add --no-cache \
 
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
-RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
+RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
+  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
+    # because jlink fails with the error "jmods: Value too large for defined data type" error.
+    # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
+    # Noting there isn't any JMODs shipped anymore since https://adoptium.net/en-GB/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled
+    cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+  else \
+    case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
@@ -52,7 +59,8 @@ RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
       ${options} \
       --no-man-pages \
       --no-header-files \
-      --output /javaruntime
+      --output /javaruntime; \
+  fi
 
 ## Agent image target
 FROM alpine:"${ALPINE_TAG}" AS agent

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,11 +45,17 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN if [[ "${TARGETPLATFORM}" != "linux/arm/v7" ]]; then \
+RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
+  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
+    # because jlink fails with the error "jmods: Value too large for defined data type" error.
+    # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
+    # Noting there isn't any JMODs shipped anymore since https://adoptium.net/en-GB/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled
+    cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+  else \
     case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
@@ -58,10 +64,6 @@ RUN if [[ "${TARGETPLATFORM}" != "linux/arm/v7" ]]; then \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime; \
-  else \
-    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
-    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
-    cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
   fi
 
 ## Agent image target

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -23,10 +23,17 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
-      "17") options="--compress=2 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
-      "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH --module-path /opt/jdk-${JAVA_VERSION}/jmods" ;; \
-      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se" ;; \
+RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
+  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
+    # because jlink fails with the error "jmods: Value too large for defined data type" error.
+    # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
+    # Noting there isn't any JMODs shipped anymore since https://adoptium.net/en-GB/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled
+    cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+  else \
+    case "$(jlink --version 2>&1 | cut -c1-2)" in \
+      "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
+      "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
@@ -34,7 +41,8 @@ RUN case "$(jlink --version 2>&1 | cut -c1-2)" in \
       ${options} \
       --no-man-pages \
       --no-header-files \
-      --output /javaruntime
+      --output /javaruntime; \
+  fi
 
 FROM registry.access.redhat.com/ubi9/ubi:"${UBI9_TAG}" AS agent
 


### PR DESCRIPTION
This change removes with https://github.com/jenkinsci/docker-agents/pull/1128/commits/66275f3c0fd95d9f623e03c8c9871d05fe695b2f the use of `jlink` (for smaller image size) for Linux JDK25 images as it's currently not comprehensively tested and validated, and caused error.

Extracted from:
- #1128 

> [!NOTE]
> - Windows agents images are not concerned as they don't use `jlink`.
> - Align with controller JDK25 image, currently not using `jlink` cf https://github.com/jenkinsci/docker/pull/2146#issuecomment-3695997595

Refs:
- https://github.com/jenkinsci/docker-agents/pull/1024#discussion_r2687020949 (placeholder until a dedicated issue is created)
- https://github.com/jenkinsci/docker-agents/issues/1124#issuecomment-3749484756

### Testing done

`make test`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
