### PR TITLE
chore: allow to build and publish experimental Linux images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,12 @@ def parallelStages = [failFast: false]
     'windowsservercore-ltsc2022'
 ].each { imageType ->
     parallelStages[imageType] = {
-        withEnv(["IMAGE_TYPE=${imageType}", "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"]) {
+        withEnv([
+            "IMAGE_TYPE=${imageType}",
+            "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}",
+            // Set to "true" to enable experimental image(s) publication
+            "PUBLISH_EXPERIMENTAL=false"
+        ]) {
             int retryCounter = 0
             retry(count: 2, conditions: [agent(), nonresumable()]) {
                 // Use local variable to manage concurrency and increment BEFORE spinning up any agent

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ prepare-test: bats check-reqs
 publish:
 	@set -x; $(bake_base_cli) linux --push
 
+# Strip experimental prefix if present
+strip_experimental = $(patsubst experimental-jlink_%,%,$(1))
+
 ## Define bats options based on environment
 # common flags for all tests
 bats_flags := ""
@@ -105,9 +108,9 @@ test-%: prepare-test
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
-	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
+	IMAGE=$(call strip_experimental,$*) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(call strip_experimental,$*) |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
 else
-	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags)
+	IMAGE=$(call strip_experimental,$*) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(call strip_experimental,$*) |  cut -d "_" -f 1).bats $(bats_flags)
 endif
 
 test: prepare-test

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,8 +41,9 @@ RUN apk add --no-cache \
 
 ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 
+ARG EXPERIMENTAL_JLINK=false
 RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
-  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+  if test "${EXPERIMENTAL_JLINK}" = "false" && [ "${TARGETPLATFORM}" = "linux/arm/v7" ] || [ "${java_major_version}" = "25" ]; then \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
     # because jlink fails with the error "jmods: Value too large for defined data type" error.
     # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
@@ -52,6 +53,8 @@ RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
     case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
+      # Experimental
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se";; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -45,8 +45,9 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+ARG EXPERIMENTAL_JLINK=false
 RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
-  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+  if test "${EXPERIMENTAL_JLINK}" = "false" && [ "${TARGETPLATFORM}" = "linux/arm/v7" ] || [ "${java_major_version}" = "25" ]; then \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
     # because jlink fails with the error "jmods: Value too large for defined data type" error.
     # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
@@ -56,6 +57,8 @@ RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
     case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
+      # Experimental
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se";; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/rhel/ubi9/Dockerfile
+++ b/rhel/ubi9/Dockerfile
@@ -23,8 +23,9 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+ARG EXPERIMENTAL_JLINK=false
 RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
-  if [[ "${TARGETPLATFORM}" == "linux/arm/v7" || "${java_major_version}" == 25 ]]; then \
+  if test "${EXPERIMENTAL_JLINK}" = "false" && [ "${TARGETPLATFORM}" = "linux/arm/v7" ] || [ "${java_major_version}" = "25" ]; then \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment
     # because jlink fails with the error "jmods: Value too large for defined data type" error.
     # For JDK25, we need to have a proper test and validation process first cf https://github.com/jenkinsci/docker-agents/issues/1124)
@@ -34,6 +35,8 @@ RUN java_major_version="$(jlink --version 2>&1 | cut -c1-2)"; \
     case "$(jlink --version 2>&1 | cut -c1-2)" in \
       "17") options="--compress=2 --add-modules ALL-MODULE-PATH" ;; \
       "21") options="--compress=zip-6 --add-modules ALL-MODULE-PATH" ;; \
+      # Experimental
+      "25") options="--compress=zip-6 --add-modules java.base,java.logging,java.xml,java.se";; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/tests/golden/expected_tags_linux.txt
+++ b/tests/golden/expected_tags_linux.txt
@@ -37,6 +37,7 @@ docker.io/jenkins/agent:trixie
 docker.io/jenkins/agent:trixie-jdk17
 docker.io/jenkins/agent:trixie-jdk21
 docker.io/jenkins/agent:trixie-jdk25
+docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready
 docker.io/jenkins/inbound-agent:alpine
 docker.io/jenkins/inbound-agent:alpine-jdk17
 docker.io/jenkins/inbound-agent:alpine-jdk21

--- a/tests/golden/expected_tags_linux_on_tag.txt
+++ b/tests/golden/expected_tags_linux_on_tag.txt
@@ -62,6 +62,7 @@ docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-alpine3.23
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-alpine3.23-jdk17
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-alpine3.23-jdk21
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-alpine3.23-jdk25
+docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-jdk17
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-jdk21
 docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-jdk25


### PR DESCRIPTION
This change allow to build and publish experimental inbound agent image using `jlink`.

By default using a Debian JDK25 image as base, it cCan be extended to other distributions and experiments if needed.

If `PUBLISH_EXPERIMENTAL` is set to true, the experimental image would be published with a unique tag like  `3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready`.

Extracted from:
- https://github.com/jenkinsci/docker-agents/pull/1128

Refs:
- https://github.com/jenkinsci/docker-agents/issues/1124#issuecomment-3750368330
- https://github.com/jenkinsci/docker-agents/issues/1131

### Testing done

```bash
$ make test
$ make test-experimental

$  make list
agent_alpine_jdk21
agent_alpine_jdk25
agent_debian_jdk17
agent_debian_jdk21
agent_debian_jdk25
agent_rhel_ubi9_jdk17
agent_rhel_ubi9_jdk21
agent_rhel_ubi9_jdk25
inbound-agent_alpine_jdk21
inbound-agent_alpine_jdk25
inbound-agent_debian_jdk17
inbound-agent_debian_jdk21
inbound-agent_debian_jdk25
inbound-agent_debian_jdk25_experimental-jlink
inbound-agent_rhel_ubi9_jdk17
inbound-agent_rhel_ubi9_jdk21
inbound-agent_rhel_ubi9_jdk25
```
```json
$ make show-experimental
{
  "group": {
    "default": {
      "targets": [
        "experimental"
      ]
    },
    "experimental": {
      "targets": [
        "experimental_jlink"
      ]
    },
    "experimental_jlink": {
      "targets": [
        "inbound-agent_debian_jdk25_experimental-jlink"
      ]
    }
  },
  "target": {
    "inbound-agent_debian_jdk25_experimental-jlink": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "trixie-20260112",
        "EXPERIMENTAL_JLINK": "true",
        "JAVA_VERSION": "25.0.1+8",
        "VERSION": "3355.v388858a_47b_33"
      },
      "labels": {
        "org.opencontainers.image.title": "Jenkins experimental debian_jdk25 image using jlink"
      },
      "tags": [
        "docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready"
      ],
      "target": "inbound-agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ],
      "output": [
        {
          "type": "cacheonly"
        }
      ]
    }
  }
}
```
```bash
# Check that no experimental image is pushed on publication by default if PUBLISH_EXPERIMENTAL is not set
$ export DOCKERHUB_ORGANISATION=hlemeur
$ ./build.sh publish
$ curl -s "https://registry.hub.docker.com/v2/repositories/${DOCKERHUB_ORGANISATION}/inbound-agent/tags?page_size=100" \
   | jq -r '.results[].name' | sort
3192.v713e3b_039fb_e-1-jdk21
3355.v388858a_47b_33-1
3355.v388858a_47b_33-1-alpine
3355.v388858a_47b_33-1-alpine-jdk17
3355.v388858a_47b_33-1-alpine-jdk21
3355.v388858a_47b_33-1-alpine-jdk25
3355.v388858a_47b_33-1-alpine3.23
3355.v388858a_47b_33-1-alpine3.23-jdk17
3355.v388858a_47b_33-1-alpine3.23-jdk21
3355.v388858a_47b_33-1-alpine3.23-jdk25
3355.v388858a_47b_33-1-inbound-agent_debian_jdk25-experimental-jlink-not-prod-ready
3355.v388858a_47b_33-1-jdk17
3355.v388858a_47b_33-1-jdk21
3355.v388858a_47b_33-1-jdk25
3355.v388858a_47b_33-1-rhel-ubi9
3355.v388858a_47b_33-1-rhel-ubi9-jdk17
3355.v388858a_47b_33-1-rhel-ubi9-jdk21
3355.v388858a_47b_33-1-rhel-ubi9-jdk25
alpine
alpine-jdk17
alpine-jdk21
alpine-jdk25
alpine3.23
alpine3.23-jdk17
alpine3.23-jdk21
alpine3.23-jdk25
bookworm-jdk21
jdk17
jdk21
jdk25
latest
latest-alpine
latest-alpine-jdk17
latest-alpine-jdk21
latest-alpine-jdk25
latest-alpine3.23
latest-alpine3.23-jdk17
latest-alpine3.23-jdk21
latest-alpine3.23-jdk25
latest-bookworm-jdk21
latest-jdk17
latest-jdk21
latest-jdk25
latest-rhel-ubi9
latest-rhel-ubi9-jdk17
latest-rhel-ubi9-jdk21
latest-rhel-ubi9-jdk25
latest-trixie
latest-trixie-jdk17
latest-trixie-jdk21
latest-trixie-jdk25
rhel-ubi9
rhel-ubi9-jdk17
rhel-ubi9-jdk21
rhel-ubi9-jdk25
trixie
trixie-jdk17
trixie-jdk21
trixie-jdk25

# Check that experimental image is pushed on publication if PUBLISH_EXPERIMENTAL is set to true
$ export PUBLISH_EXPERIMENTAL=true
```
```json
$ make show-experimental
{
  "group": {
    "default": {
      "targets": [
        "experimental"
      ]
    },
    "experimental": {
      "targets": [
        "experimental_jlink"
      ]
    },
    "experimental_jlink": {
      "targets": [
        "inbound-agent_debian_jdk25_experimental-jlink"
      ]
    }
  },
  "target": {
    "inbound-agent_debian_jdk25_experimental-jlink": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "DEBIAN_RELEASE": "trixie-20260112",
        "EXPERIMENTAL_JLINK": "true",
        "JAVA_VERSION": "25.0.1+8",
        "VERSION": "3355.v388858a_47b_33"
      },
      "labels": {
        "org.opencontainers.image.title": "Jenkins experimental debian_jdk25 image using jlink"
      },
      "tags": [
        "docker.io/jenkins/inbound-agent:3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready"
      ],
      "target": "inbound-agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le",
        "linux/s390x"
      ],
      "output": [
        {
          "type": "image"
        },
        {
          "type": "docker"
        }
      ]
    }
  }
}
```
```bash
$ ./build.sh publish
$ curl -s "https://registry.hub.docker.com/v2/repositories/${DOCKERHUB_ORGANISATION}/inbound-agent/tags?page_size=100" \
   | jq -r '.results[].name' | sort | grep experimental
3355.v388858a_47b_33-1-debian_jdk25-experimental-jlink-not-prod-ready
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
