### PR TITLE
chore(pipeline): use `infra.getBuildAgentLabel` in `agentSelector`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,17 +10,17 @@ def agentSelector(String imageType, retryCounter) {
     def platform
     switch (imageType) {
         // nanoserver-1809, nanoserver-ltsc2019 and windowservercore-ltsc2019
-        case ~/.*9/:
+        case ~/.*(1809|2019)/:
             platform = 'windows-2019'
             break
 
         // nanoserver-ltsc2022 and windowservercore-ltsc2022
-        case ~/.*2/:
+        case ~/.*2022/:
             platform = 'windows-2022'
             break
 
         // nanoserver-ltsc2025 and windowservercore-ltsc2025
-        case ~/.*5/:
+        case ~/.*2025/:
             platform = 'windows-2025'
             break
 


### PR DESCRIPTION
This change replaces the multiple `if` cases and the `spotSelector` function by a call to the `infra.getAgentLabel` global pipeline library function, as a centralised point to retrieve the appropriate agent template labels depending on the requested platform (no JDK implicated in those docker image builds), and on the controller where the job is running (ex: "fallback to from `docker-highmem` to `linux`" or "no `spot`/`nonspot` labels" on trusted.ci.jenkins.io).

Recommanded view: https://github.com/jenkinsci/docker-agents/pull/1137/changes?diff=split

Extracted from:
- #1110
- PR resumed to [this change](https://github.com/jenkinsci/docker-agents/pull/1110/changes/d17aee70aaf652bcbf310c07677431752bf1da5d..HEAD) when including this one

Refs:
- https://github.com/jenkins-infra/pipeline-library/pull/980
- https://github.com/jenkins-infra/pipeline-library/pull/985

### Testing done

CI + `infra.getBuildAgentLabel` unit tests

> <img width="823" height="354" alt="image" src="https://github.com/user-attachments/assets/acb0937e-7279-4054-9225-c4a04a27fd5e" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
