### PR TITLE
chore(windows/make.ps1) ensure Pester is only installed as user (instead of system)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -264,5 +264,3 @@ if ($lastExitCode -ne 0) {
     Write-Host '= Build finished successfully'
 }
 exit $lastExitCode
-
-


### PR DESCRIPTION
Caused by https://github.com/jenkins-infra/helpdesk/issues/4939#issuecomment-3798893664

Ref. https://learn.microsoft.com/en-us/powershell/module/powershellget/install-module?view=powershellget-2.x#example-5-install-a-module-only-for-the-current-user


Same as https://github.com/jenkinsci/docker/pull/2236
