### PR TITLE
chore(github): add `skip-changelog` label to GitHub actions dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
 
 # GitHub actions
 - package-ecosystem: "github-actions"
+  labels:
+    - "skip-changelog"
   target-branch: master
   directory: "/"
   schedule:


### PR DESCRIPTION
Having those PRs in release changelogs is not really useful for users.

Refs:
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#labels--
- https://github.com/jenkinsci/docker-ssh-agent/pull/351

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
