### PR TITLE
chore(build.ps1): improve docker compose file generation and add `docker-init` target

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -129,8 +129,6 @@ function Initialize-DockerComposeFile {
         [String] $DockerComposeFile
     )
 
-    $baseDockerBakeCmd = 'docker buildx bake --progress=plain --file=docker-bake.hcl'
-
     $items = $ImageType.Split('-')
     $windowsFlavor = $items[0]
     $windowsVersion = $items[1]
@@ -146,22 +144,22 @@ function Initialize-DockerComposeFile {
     # For each target name as service key, return a map consisting of:
     # - 'image' set to the first tag value
     # - 'build' set to the content of the bake target
-    $yqMainQuery = '''.target[]' + `
-        ' | del(.output)' + `
-        ' | {(. | key): {\"image\": .tags[0], \"build\": .}}'''
+    $yqMainQuery = '.target[] | del(.output) | {(. | key): {"image": .tags[0], "build": .}}'
     # Encapsulate under a top level 'services' map
-    $yqServicesQuery = '''{\"services\": .}'''
+    $yqServicesQuery = '{"services": .}'
+
+    if ($PSVersionTable.PSVersion.Major -eq 5) {
+        $yqMainQuery = $yqMainQuery -replace '"', '\"'
+        $yqServicesQuery = $yqServicesQuery -replace '"', '\"'
+    }
 
     # - Use docker buildx bake to output image definitions from the "<windowsFlavor>" bake target
     # - Convert with yq to the format expected by docker compose
     # - Store the result in the docker compose file
-    $generateDockerComposeFileCmd = ' {0} {1} --print' -f $baseDockerBakeCmd, $windowsFlavor + `
-        ' | yq --prettyPrint {0} | yq {1}' -f $yqMainQuery, $yqServicesQuery + `
-        ' | Out-File -FilePath {0}' -f $DockerComposeFile
-
-    Write-Host "= PREPARE: Docker compose file generation command`n$generateDockerComposeFileCmd"
-
-    Invoke-Expression $generateDockerComposeFileCmd
+    docker buildx bake --progress=quiet --file=docker-bake.hcl $windowsFlavor --print |
+        yq --prettyPrint $yqMainQuery |
+        yq $yqServicesQuery |
+        Out-File -FilePath $DockerComposeFile
 
     # Remove override
     Remove-Item env:\WINDOWS_VERSION_OVERRIDE
@@ -185,16 +183,16 @@ foreach($agentType in $AgentTypes) {
 
     # Generate the docker compose file if it doesn't exists or if the parameter OverwriteDockerComposeFile is set
     if ((Test-Path $dockerComposeFile) -and -not $OverwriteDockerComposeFile) {
-        Write-Host "= PREPARE: The docker compose file '$dockerComposeFile' containing the image definitions already exists."
+        Write-Host "= PREPARE: The docker compose file '$dockerComposeFile' containing the $agentType image definitions already exists."
     } else {
-        Write-Host "= PREPARE: Initialize the docker compose file '$dockerComposeFile' containing the image definitions."
+        Write-Host "= PREPARE: Generate docker compose file '$dockerComposeFile' containing the $agentType image definitions."
         Initialize-DockerComposeFile -AgentType $AgentType -ImageType $ImageType -DockerComposeFile $dockerComposeFile
     }
 
-    Write-Host '= PREPARE: List of images and tags to be processed:'
-    Invoke-Expression "$baseDockerCmd config"
-
     if ($Target -eq 'build') {
+        Write-Host '= PREPARE: List of images and tags to be processed:'
+        Invoke-Expression "$baseDockerCmd config"
+
         Write-Host '= BUILD: Building all images...'
         switch ($DryRun) {
             $true { Write-Host "(dry-run) $baseDockerBuildCmd" }


### PR DESCRIPTION
This change adds a `docker-init` target, uses the proper case for `$Target`, and improves the docker compose files generation to be quieter, cleaner[^1] and compatible with both PowerShell 5 and PowerShell 7[^2].

Extracted from:
- #1156 

### Testing done

```
$ pwsh
PowerShell 7.5.3

   A new PowerShell stable release is available: v7.5.4 
   Upgrade now, or check out the release page at:       
     https://aka.ms/PowerShell-Release?tag=v7.5.4       

PS /Users/vv/oss/docker-agents--misc> ./make.ps1 docker-init                       
= INIT: docker info below
Client:
 Version:    29.0.1
 Context:    desktop-linux
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.29.1-desktop.1
    Path:     /Users/vv/.docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v2.40.3-desktop.1
    Path:     /Users/vv/.docker/cli-plugins/docker-compose

Server:
 Containers: 1
  Running: 0
  Paused: 0
  Stopped: 1
 Images: 145
 Server Version: 29.0.1
 Storage Driver: overlayfs
  driver-type: io.containerd.snapshotter.v1
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
 CDI spec directories:
  /etc/cdi
  /var/run/cdi
 Swarm: inactive
 Runtimes: runc io.containerd.runc.v2
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: fcd43222d6b07379a4be9786bda52438f0dd16a1
 runc version: v1.3.3-0-gd842d771
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.12.54-linuxkit
 Operating System: Docker Desktop
 OSType: linux
 Architecture: aarch64
 CPUs: 14
 Total Memory: 15.6GiB
 Name: docker-desktop
 ID: 3f45f2fa-3d59-4398-8d8c-cdd5a4cca58c
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 HTTP Proxy: http.docker.internal:3128
 HTTPS Proxy: http.docker.internal:3128
 No Proxy: hubproxy.docker.internal
 Labels:
  com.docker.desktop.address=unix:///Users/vv/Library/Containers/com.docker.docker/Data/docker-cli.sock
 Experimental: false
 Insecure Registries:
  hubproxy.docker.internal:5555
  ::1/128
  127.0.0.0/8
 Live Restore Enabled: false

= PREPARE: Generate docker compose file 'build-windows_agent_nanoserver-ltsc2019.yaml' containing the agent image definitions.
= PREPARE: Generate docker compose file 'build-windows_inbound-agent_nanoserver-ltsc2019.yaml' containing the inbound-agent image definitions.
= Build finished successfully
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

[^1]: No false "error" in `powershell` step logs when calling `docker buildx --print`, better log info order and content.
[^2]: So `./build.ps1` can be executed from any PowerShell version, not only the (outdated) 5th.