### PR TITLE
chore(updatecli): target `build.ps1` renamed to `make.ps1`

### DIFF
--- a/updatecli/updatecli.d/remoting.yaml
+++ b/updatecli/updatecli.d/remoting.yaml
@@ -88,10 +88,10 @@ targets:
         remoting_version="{{ source "lastVersion" }}"
     scmid: default
   setWindowsBuildPwshRemotingVersion:
-    name: Bump the Jenkins remoting version on the windows build.ps1 file
+    name: Bump the Jenkins remoting version on the windows make.ps1 file
     kind: file
     spec:
-      file: build.ps1
+      file: make.ps1
       matchpattern: >-
         \$RemotingVersion(.*)=(.*),
       replacepattern: >-


### PR DESCRIPTION
Follow-up of:
- https://github.com/jenkinsci/docker-agents/pull/1156 (more precisely https://github.com/jenkinsci/docker-agents/pull/1156/changes/1dae385d6b976fe3df3d465ba35e9c4492295d32)

### Testing done

<details><summary>updatecli diff --config ./updatecli/updatecli.d/remoting.yaml --values ./updatecli/values.github-action.yaml</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/remoting.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


#####################################
# BUMP THE JENKINS REMOTING VERSION #
#####################################

Pipeline ID     : f6a489d37e8857f35964f836eece704672730157ea40050f8c93f426069a562c
Dry Run         : enabled

source: lastVersion
-------------------

Searching for version matching pattern "latest"
✔ GitHub release version "3355.v388858a_47b_33" found matching pattern "latest" of kind "latest"

condition: checkJarIsAvailable
------------------------------

The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/fb52b0391415ed3eba3e0311d7a82de892140eb754c9866df75ad12232274a56.sh" ran successfully with the following output:
----
----
✔ shell condition of type "console/output", passing

target: setAlpineDockerImage
----------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ The line #99, matched by the keyword "ARG" and the matcher "VERSION", is correctly set to "ARG VERSION=3355.v388858a_47b_33".
✔ - 

target: setWindowsBuildPwshRemotingVersion
------------------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ - all contents from 'file' and 'files' combined already up to date

target: updateReadmeRemotingVersion
-----------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ - all contents from 'file' and 'files' combined already up to date

target: setDockerBakeDefaultParentImage
---------------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ - no changes detected:
        path "variable.REMOTING_VERSION.default" already set to "3355.v388858a_47b_33", from file "docker-bake.hcl", 

target: setNanoserverDockerImage
--------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ The line #103, matched by the keyword "ARG" and the matcher "VERSION", is correctly set to "ARG VERSION=3355.v388858a_47b_33".
✔ - 

target: setLinuxBuildShRemotingVersion
--------------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ - all contents from 'file' and 'files' combined already up to date

target: setDebianDockerImage
----------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ The line #103, matched by the keyword "ARG" and the matcher "VERSION", is correctly set to "ARG VERSION=3355.v388858a_47b_33".
✔ - 

target: setWindowsServerCoreDockerImage
---------------------------------------

Repository      : github.com/jenkinsci/docker-agent@master

✔ The line #97, matched by the keyword "ARG" and the matcher "VERSION", is correctly set to "ARG VERSION=3355.v388858a_47b_33".
✔ - 


ACTIONS
========

---
Pipeline Name   : Bump the Jenkins remoting version
Pipeline ID     : f6a489d37e8857f35964f836eece704672730157ea40050f8c93f426069a562c
Dry run         : true
Repository      : github.com/jenkinsci/docker-agent@master
Action          : Bump the Jenkins remoting version to 3355.v388858a_47b_33
---

No follow up action needed

=============================

SUMMARY:

✔ Bump the Jenkins remoting version:
        Source:
                ✔ [lastVersion] Get the latest version of the Jenkins remoting
        Condition:
                ✔ [checkJarIsAvailable] Check that the JAR file for remoting is available
        Target:
                ✔ [setAlpineDockerImage] Bump the Jenkins remoting version on Alpine
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setDebianDockerImage] Bump the Jenkins remoting version on Debian Bullseye
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setDockerBakeDefaultParentImage] Bump the Jenkins remoting version on the docker-bake.hcl file
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setLinuxBuildShRemotingVersion] Bump the Jenkins remoting version on the linux build.sh file
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setNanoserverDockerImage] Bump the Jenkins remoting version on Windows Nanoserver
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setWindowsBuildPwshRemotingVersion] Bump the Jenkins remoting version on the windows make.ps1 file
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [setWindowsServerCoreDockerImage] Bump the Jenkins remoting version on Windows Server Core
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
                ✔ [updateReadmeRemotingVersion] Update the remoting version in the README.md file
                      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
 ```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
