### PR TITLE
chore(pipeline): batch Linux images publication by distribution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,12 @@ def parallelStages = [failFast: false]
                                 // This function is defined in the jenkins-infra/pipeline-library
                                 infra.withDockerCredentials {
                                     if (isUnix()) {
-                                        sh 'make "publish${MAKE_TARGET_SUFFIX}"'
+                                        if (imageType != 'linux') {
+                                            sh 'make "publish${MAKE_TARGET_SUFFIX}"'
+                                        } else {
+                                            // Batch Linux images publication by distribution to avoid 429 rate limit errors from Docker Hub
+                                            sh 'make listgroup-linux | xargs -I {} make "publish-{}"'
+                                        }
                                     } else {
                                         powershell './make.ps1 publish'
                                     }

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,10 @@ list-%: check-reqs
 listarch-%: check-reqs
 	@set -x; make --silent showarch-$* | jq -r '.target | keys[]'
 
+# Return the list of targets of a specific bake group
+listgroup-%: check-reqs
+	@set -x; make --silent show-$* | jq -r '.group | keys[]' | grep -v -e $* -e default
+
 # Ensure bats exists in the current folder
 bats:
 	git clone --branch v1.13.0 https://github.com/bats-core/bats-core ./bats


### PR DESCRIPTION
This change allows to batch Linux images publication by distribution, to avoid the 429 rate limit errors from Docker Hub we're encountering since a few weeks already.

To be confirmed by an actual release.

If it appears this is not enough, further batching could be implemented from this base, with additional splitting between agent/inbound-agent or JDKs for example.

Note: it doesn't change builds and tests on ci.jenkins.io, neither it prevents replays on selected targets (cf #1159).

Refs:
- https://github.com/jenkinsci/docker-agents/issues/1163
- https://github.com/jenkinsci/docker-agents/issues/1160#issuecomment-3903758174

### Testing done

```bash
$ make listgroup-linux | xargs -I {} echo "publish-{}"
+ make --silent show-linux
+ jq -r '.group | keys[]'
+ grep -v -e linux -e default
+ docker buildx bake --file docker-bake.hcl --progress=quiet --print linux
+ jq
publish-alpine
publish-debian
publish-rhel_ubi9

# Expected targets and architecture from one of those distributions
$ make publish-alpine
+ docker buildx bake --file docker-bake.hcl --progress=quiet --print rhel_ubi9
+ jq
...
```
<details><summary>[JSON output]</summary>

```json
{
  "group": {
    "default": {
      "targets": [
        "rhel_ubi9"
      ]
    },
    "rhel_ubi9": {
      "targets": [
        "agent_rhel_ubi9_jdk17",
        "agent_rhel_ubi9_jdk21",
        "agent_rhel_ubi9_jdk25",
        "inbound-agent_rhel_ubi9_jdk17",
        "inbound-agent_rhel_ubi9_jdk21",
        "inbound-agent_rhel_ubi9_jdk25"
      ]
    }
  },
  "target": {
    "agent_rhel_ubi9_jdk17": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "17.0.18_8",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/agent:rhel-ubi9-jdk17",
        "docker.io/jenkins/agent:latest-rhel-ubi9-jdk17"
      ],
      "target": "agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "agent_rhel_ubi9_jdk21": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "21.0.10_7",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/agent:rhel-ubi9",
        "docker.io/jenkins/agent:latest-rhel-ubi9",
        "docker.io/jenkins/agent:rhel-ubi9-jdk21",
        "docker.io/jenkins/agent:latest-rhel-ubi9-jdk21"
      ],
      "target": "agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "agent_rhel_ubi9_jdk25": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "25.0.2_10",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/agent:rhel-ubi9-jdk25",
        "docker.io/jenkins/agent:latest-rhel-ubi9-jdk25"
      ],
      "target": "agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "inbound-agent_rhel_ubi9_jdk17": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "17.0.18_8",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/inbound-agent:rhel-ubi9-jdk17",
        "docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk17"
      ],
      "target": "inbound-agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "inbound-agent_rhel_ubi9_jdk21": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "21.0.10_7",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/inbound-agent:rhel-ubi9",
        "docker.io/jenkins/inbound-agent:latest-rhel-ubi9",
        "docker.io/jenkins/inbound-agent:rhel-ubi9-jdk21",
        "docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk21"
      ],
      "target": "inbound-agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    },
    "inbound-agent_rhel_ubi9_jdk25": {
      "context": ".",
      "dockerfile": "rhel/ubi9/Dockerfile",
      "args": {
        "JAVA_VERSION": "25.0.2_10",
        "UBI9_TAG": "9.7-1770238273",
        "VERSION": "3355.v388858a_47b_33"
      },
      "tags": [
        "docker.io/jenkins/inbound-agent:rhel-ubi9-jdk25",
        "docker.io/jenkins/inbound-agent:latest-rhel-ubi9-jdk25"
      ],
      "target": "inbound-agent",
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/ppc64le"
      ]
    }
  }
}
```

</details>

```bash
...
+ docker buildx bake --file docker-bake.hcl --metadata-file=target/build-result-metadata_rhel_ubi9_publish.json --push rhel_ubi9
#0 building with "desktop-linux" instance using docker driver
<snip>
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
