### PR TITLE
fix(pipeline): use `infra.withDockerCredentials` in all stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,65 +83,65 @@ def parallelStages = [failFast: false]
                 node(resolvedAgentLabel) {
                     timeout(time: 60, unit: 'MINUTES') {
                         checkout scm
-                        stage("Prepare Docker on ${resolvedAgentLabel}") {
-                            if (isUnix()) {
-                                sh 'make docker-init'
-                            } else {
-                                powershell './make.ps1 docker-init'
-                                archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
-                            }
-                        }
-
-                        if (isUnix()) {
-                            stage('Checks') {
-                                sh 'make hadolint'
-                                sh 'make shellcheck'
-                            }
-                        }
-
-                        // No single arch build or test on trusted.ci.jenkins.io
-                        if (!infra.isTrusted()) {
-                            // Build current arch for Linux images
-                            stage('Build current arch') {
+                        // This function is defined in the jenkins-infra/pipeline-library
+                        infra.withDockerCredentials {
+                            stage("Prepare Docker on ${resolvedAgentLabel}") {
                                 if (isUnix()) {
-                                    sh 'make "build${MAKE_TARGET_SUFFIX}"'
+                                    sh 'make docker-init'
                                 } else {
-                                    // No multiarch Windows images
+                                    powershell './make.ps1 docker-init'
+                                    archiveArtifacts artifacts: 'build-windows_*.yaml', allowEmptyArchive: true
+                                }
+                            }
+
+                            if (isUnix()) {
+                                stage('Checks') {
+                                    sh 'make hadolint'
+                                    sh 'make shellcheck'
+                                }
+                            }
+
+                            // No single arch build or test on trusted.ci.jenkins.io
+                            if (!infra.isTrusted()) {
+                                // Build current arch for Linux images
+                                stage('Build current arch') {
+                                    if (isUnix()) {
+                                        sh 'make "build${MAKE_TARGET_SUFFIX}"'
+                                    } else {
+                                        // No multiarch Windows images
+                                        powershell './make.ps1 build'
+                                    }
+                                }
+
+                                stage('Test') {
+                                    if (isUnix()) {
+                                        sh 'make "test${MAKE_TARGET_SUFFIX}"'
+                                    } else {
+                                        powershell './make.ps1 test'
+                                    }
+                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results*.xml')
+                                }
+                                archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
+                            }
+
+                            // If the tests are passing for Linux AMD64 or if we're on trusted.ci.jenkins.io
+                            // then we build all the CPU architectures
+                            stage('Build multiarch') {
+                                if (isUnix()) {
+                                    sh 'make "multiarchbuild${MAKE_TARGET_SUFFIX}"'
+                                } else {
+                                    // No multiarch images for Windows, (re)building them here on both controllers
                                     powershell './make.ps1 build'
                                 }
+                                archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
                             }
 
-                            stage('Test') {
-                                if (isUnix()) {
-                                    sh 'make "test${MAKE_TARGET_SUFFIX}"'
-                                } else {
-                                    powershell './make.ps1 test'
-                                }
-                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results*.xml')
-                            }
-                            archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
-                        }
-
-                        // If the tests are passing for Linux AMD64 or if we're on trusted.ci.jenkins.io
-                        // then we build all the CPU architectures
-                        stage('Build multiarch') {
-                            if (isUnix()) {
-                                sh 'make "multiarchbuild${MAKE_TARGET_SUFFIX}"'
-                            } else {
-                                // No multiarch images for Windows, (re)building them here on both controllers
-                                powershell './make.ps1 build'
-                            }
-                            archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
-                        }
-
-                        // trusted.ci.jenkins.io builds (e.g. publication to DockerHub)
-                        if (infra.isTrusted()) {
-                            stage('Deploy to DockerHub') {
-                                if (!tagWithOneDashExist) {
-                                    error("The deployment to Docker Hub failed because the tag doesn't contain any '-'.")
-                                }
-                                // This function is defined in the jenkins-infra/pipeline-library
-                                infra.withDockerCredentials {
+                            // trusted.ci.jenkins.io builds (e.g. publication to DockerHub)
+                            if (infra.isTrusted()) {
+                                stage('Deploy to DockerHub') {
+                                    if (!tagWithOneDashExist) {
+                                        error("The deployment to Docker Hub failed because the tag doesn't contain any '-'.")
+                                    }
                                     if (isUnix()) {
                                         if (imageType != 'linux') {
                                             sh 'make "publish${MAKE_TARGET_SUFFIX}"'
@@ -152,8 +152,8 @@ def parallelStages = [failFast: false]
                                     } else {
                                         powershell './make.ps1 publish'
                                     }
+                                    archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
                                 }
-                                archiveArtifacts artifacts: 'target/build-result-metadata_*.json', allowEmptyArchive: true
                             }
                         }
                     }


### PR DESCRIPTION
This change ensures we're logged in Docker Hub in all stages and all controllers, not only the publication one on trusted.ci.jenkins.io

Best reviewed without whitespace: https://github.com/jenkinsci/docker-agents/pull/1166/changes?diff=unified&w=1

Ref:
- https://github.com/jenkinsci/docker-agents/issues/1163#issuecomment-3926946897

### Testing done

CI

I'll also test a publication on trusted.ci without #1162 to see if we still encounter 429 rate limit errors.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
