### PR TITLE
chore(updatecli): check for `linux/riscv64` architecture in JDK manifests

### DIFF
--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -47,6 +47,7 @@ conditions:
         - linux/s390x
         - windows/x64
         - linux/arm
+        - linux/riscv64
 
 targets:
   setJDK17VersionDockerBake:

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -46,6 +46,7 @@ conditions:
         - linux/aarch64
         - linux/ppc64le
         - linux/s390x
+        - linux/riscv64
         - windows/x64
 
 targets:

--- a/updatecli/updatecli.d/jdk25.yaml
+++ b/updatecli/updatecli.d/jdk25.yaml
@@ -46,6 +46,7 @@ conditions:
         - linux/aarch64
         - linux/ppc64le
         - linux/s390x
+        - linux/riscv64
         - windows/x64
 
 targets:


### PR DESCRIPTION
Follow-up of:
- #1172

Ref:
- #1168 

### Testing done

```
$ updatecli diff --config ./updatecli/updatecli.d/jdk17.yaml --values ./updatecli/values.github-action.yaml 

<...snip...>

[temurin] using specific version (`spec.SpecificVersion`) from source value "17.0.18+8". Set `disablesourceinput` to true to avoid this behavior.
✔ (Platform "alpine-linux/x64") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/x64") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/aarch64") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/ppc64le") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/s390x") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "windows/x64") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/arm") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ (Platform "linux/riscv64") Found release "jdk-17.0.18+8" which maps specified "17.0.18+8" version.
✔ All releases found.

<...snip...>
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
