### PR TITLE
chore: split build of `linux` images by distribution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,11 +54,13 @@ if (env.TAG_NAME) {
 }
 
 // Specify parallel stages
-// Linux: bake group(s) or target(s)
+// Linux: bake group(s) or target(s), see 'make list' or 'make listgroup-linux' output
 // Windows: flavor and version to build
 def parallelStages = [failFast: false]
 [
-    'linux',
+    'alpine',
+    'debian',
+    'rhel_ubi9',
     'nanoserver-ltsc2019',
     'nanoserver-ltsc2022',
     'windowsservercore-ltsc2019',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,15 +67,12 @@ def parallelStages = [failFast: false]
     'windowsservercore-ltsc2022'
 ].each { imageType ->
     parallelStages[imageType] = {
-        // Only bake targets can be specified with build-%, test-% and publish-% make targets
-        def makeTargetSuffix= (imageType.startsWith('agent_') || imageType.startsWith('inbound-agent_')) ? "-${imageType}" : ''
         withEnv([
             "ON_TAG=${tagWithOneDashExist}",
             "REMOTING_VERSION=${remotingVersion}",
             "BUILD_NUMBER=${buildNumber}",
             "IMAGE_TYPE=${imageType}",
-            "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}",
-            "MAKE_TARGET_SUFFIX=${makeTargetSuffix}"
+            "REGISTRY_ORG=${infra.isTrusted() ? 'jenkins' : 'jenkins4eval'}"
         ]) {
             int retryCounter = 0
             retry(count: 2, conditions: [agent(), nonresumable()]) {
@@ -106,7 +103,7 @@ def parallelStages = [failFast: false]
                             // Build current arch for Linux images
                             stage('Build current arch') {
                                 if (isUnix()) {
-                                    sh 'make "build${MAKE_TARGET_SUFFIX}"'
+                                    sh 'make "build-${IMAGE_TYPE}"'
                                 } else {
                                     // No multiarch Windows images
                                     powershell './make.ps1 build'
@@ -115,7 +112,7 @@ def parallelStages = [failFast: false]
 
                             stage('Test') {
                                 if (isUnix()) {
-                                    sh 'make "test${MAKE_TARGET_SUFFIX}"'
+                                    sh 'make "test-${IMAGE_TYPE}"'
                                 } else {
                                     powershell './make.ps1 test'
                                 }
@@ -128,7 +125,7 @@ def parallelStages = [failFast: false]
                         // then we build all the CPU architectures
                         stage('Build multiarch') {
                             if (isUnix()) {
-                                sh 'make "multiarchbuild${MAKE_TARGET_SUFFIX}"'
+                                sh 'make "multiarchbuild-${IMAGE_TYPE}"'
                             } else {
                                 // No multiarch images for Windows, (re)building them here on both controllers
                                 powershell './make.ps1 build'
@@ -146,7 +143,7 @@ def parallelStages = [failFast: false]
                                 infra.withDockerCredentials {
                                     if (isUnix()) {
                                         if (imageType != 'linux') {
-                                            sh 'make "publish${MAKE_TARGET_SUFFIX}"'
+                                            sh 'make "publish-${IMAGE_TYPE}"'
                                         } else {
                                             // Batch Linux images publication by distribution to avoid 429 rate limit errors from Docker Hub
                                             sh 'make listgroup-linux | xargs -I {} make "publish-{}"'

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-%: bats_flags += $(BATS_FLAGS)
 endif
 test-%: prepare-test
 # Check that the image exists in the manifest
-	$(call check_image,$*)
+	@$(call check_image,$*)
 # Ensure that the image is built
 	@set -x; make --silent build-$*
 	@set -x; make --silent _test-dispatch TARGET=$*

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ export ARCH ?= $(shell \
 ##### Macros
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
-## Check if a given image or linux distribution exists in the current manifest docker-bake.hcl
-check_image = make --silent list listgroup-linux  | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
+## Check if a given image or group exists in the current manifest docker-bake.hcl
+check_image = make --silent list listgroup-all  | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export ARCH ?= $(shell \
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
 ## Check if a given image or group exists in the current manifest docker-bake.hcl
-check_image = make --silent list listgroup-all  | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
+check_image = make --silent list listgroup-all | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list' or 'make listgroup-all'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)
@@ -169,7 +169,7 @@ endif
 test-%: prepare-test
 	@set -x; make --silent _test-dispatch TARGET=$*
 
-# Dispatch the test depending if the make target is a bake target or a group
+# Dispatch the test depending if it's a bake target or a group
 _test-dispatch:
 	@set -x; if make --silent listgroup-linux | grep -w "$(TARGET)" >/dev/null 2>&1; then \
 		make --silent _test-group TARGET=$(TARGET); \
@@ -177,10 +177,11 @@ _test-dispatch:
 		make --silent _test-image TARGET=$(TARGET); \
 	fi
 
-
+# Test a group by iterating on its targets
 _test-group:
 	@set -x; make --silent list-$(TARGET) | while read image; do make --silent test-$$image; done
 
+# Test an image
 _test-image:
 	@echo "Testing $(TARGET)"
 # Check that the image exists in the manifest

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ export ARCH ?= $(shell \
 ##### Macros
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
-## Check if a given image exists in the current manifest docker-bake.hcl
-check_image = make --silent list | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
+## Check if a given image or linux distribution exists in the current manifest docker-bake.hcl
+check_image = make --silent list listgroup-linux  | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)
@@ -40,7 +40,7 @@ bake_cli := $(bake_base_cli) --load
 bake_default_target := all
 
 .PHONY: build
-.PHONY: test test-alpine test-debian
+.PHONY: test
 
 check-reqs:
 ## Build requirements
@@ -167,21 +167,37 @@ ifneq (,$(BATS_FLAGS))
 test-%: bats_flags += $(BATS_FLAGS)
 endif
 test-%: prepare-test
+	@set -x; make --silent _test-dispatch TARGET=$*
+
+# Dispatch the test depending if the make target is a bake target or a group
+_test-dispatch:
+	@set -x; if make --silent listgroup-linux | grep -w "$(TARGET)" >/dev/null 2>&1; then \
+		make --silent _test-group TARGET=$(TARGET); \
+	else \
+		make --silent _test-image TARGET=$(TARGET); \
+	fi
+
+
+_test-group:
+	@set -x; make --silent list-$(TARGET) | while read image; do make --silent test-$$image; done
+
+_test-image:
+	@echo "Testing $(TARGET)"
 # Check that the image exists in the manifest
-	@$(call check_image,$*)
+	$(call check_image,$(TARGET))
 # Ensure that the image is built
-	@set -x; make --silent build-$*
+	@set -x; make --silent build-$(TARGET)
 # Show bats version
 	@set -x; bats/bin/bats --version
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
 ifeq ($(CI), true)
 # Execute the test harness and write result to a TAP file
-	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$(TARGET).xml
 else
 # Execute the test harness
-	IMAGE=$* bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $* |  cut -d "_" -f 1).bats $(bats_flags) --timing
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
 endif
 
-# Test targets depending on the current architecture
+# Test all targets depending on the current architecture
 test:
 	@set -x; make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,10 @@ ifneq (,$(BATS_FLAGS))
 test-%: bats_flags += $(BATS_FLAGS)
 endif
 test-%: prepare-test
+# Check that the image exists in the manifest
+	$(call check_image,$*)
+# Ensure that the image is built
+	@set -x; make --silent build-$*
 	@set -x; make --silent _test-dispatch TARGET=$*
 
 # Dispatch the test depending if it's a bake target or a group
@@ -184,10 +188,6 @@ _test-group:
 # Test an image
 _test-image:
 	@echo "Testing $(TARGET)"
-# Check that the image exists in the manifest
-	$(call check_image,$(TARGET))
-# Ensure that the image is built
-	@set -x; make --silent build-$(TARGET)
 # Show bats version
 	@set -x; bats/bin/bats --version
 # Each type of image ("agent" or "inbound-agent") has its own tests suite
@@ -199,6 +199,6 @@ else
 	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
 endif
 
-# Test all targets depending on the current architecture
+# Test all targets depending on the current OS and architecture
 test:
-	@set -x; make --silent list | while read image; do make --silent "test-$${image}"; done
+	@set -x; make --silent test-$(OS)


### PR DESCRIPTION
This change splits the build of `linux` images by distribution to avoid docker hub congestion/rate limits.

### Testing done

`make test-debian`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
