### PR TITLE
chore(Makefile): use `pretty` formatter when running tests locally and `$(MAKE)` instead of `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ ifeq ($(CI), true)
 	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter junit | tee target/junit-results-$(TARGET).xml
 else
 # Execute the test harness
-	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --timing
+	IMAGE=$(TARGET) bats/bin/bats $(CURDIR)/tests/tests_$(shell echo $(TARGET) |  cut -d "_" -f 1).bats $(bats_flags) --formatter pretty --timing
 endif
 
 # Test all targets depending on the current OS and architecture

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export ARCH ?= $(shell \
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
 ## Check if a given image or group exists in the current manifest docker-bake.hcl
-check_image = make --silent list listgroup-all | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list' or 'make listgroup-all'. Exiting." ; exit 1 ; }
+check_image = $(MAKE) --silent list listgroup-all | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of '$(MAKE) list' or '$(MAKE) listgroup-all'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
 bake_base_cli := docker buildx bake --file docker-bake.hcl
 ## Command to be used on build (only)
@@ -77,7 +77,7 @@ shellcheck:
 
 # Build all targets with the current OS and architecture
 build: check-reqs target showarch-$(ARCH)
-	@set -x; $(bake_cli) --metadata-file=target/build-result-metadata_$(bake_default_target).json --set '*.platform=$(OS)/$(ARCH)' $(shell make --silent list)
+	@set -x; $(bake_cli) --metadata-file=target/build-result-metadata_$(bake_default_target).json --set '*.platform=$(OS)/$(ARCH)' $(shell $(MAKE) --silent list)
 
 # Build a specific target with the current OS and architecture
 build-%: check-reqs target show-%
@@ -95,7 +95,7 @@ multiarchbuild-%: check-reqs show-%
 
 # Show all default targets
 show:
-	@set -x; make --silent show-$(bake_default_target)
+	@set -x; $(MAKE) --silent show-$(bake_default_target)
 
 # Show a specific target
 show-%:
@@ -103,31 +103,31 @@ show-%:
 
 # Show all targets depending on the architecture
 showarch-%:
-	@set -x; make --silent show | jq --arg arch "$(OS)/$*" '.target |= with_entries(select(.value.platforms | index($$arch)))'
+	@set -x; $(MAKE) --silent show | jq --arg arch "$(OS)/$*" '.target |= with_entries(select(.value.platforms | index($$arch)))'
 
 # List tags of all default targets
 tags:
-	@set -x; make --silent tags-$(bake_default_target)
+	@set -x; $(MAKE) --silent tags-$(bake_default_target)
 
 # List tags of a specific target
 tags-%:
-	@set -x; make --silent show-$* | jq -r '.target | to_entries[] | .key as $$name | .value.tags[] | "\(.) (\($$name))"' | LC_ALL=C sort -u
+	@set -x; $(MAKE) --silent show-$* | jq -r '.target | to_entries[] | .key as $$name | .value.tags[] | "\(.) (\($$name))"' | LC_ALL=C sort -u
 
 # Return the list of targets depending on the current OS and architecture
 list: check-reqs
-	@set -x; make --silent listarch-$(ARCH)
+	@set -x; $(MAKE) --silent listarch-$(ARCH)
 
 # Return the list of targets of a specific "target" (can be a docker bake group)
 list-%: check-reqs
-	@set -x; make --silent show-$* | jq -r '.target | keys[]'
+	@set -x; $(MAKE) --silent show-$* | jq -r '.target | keys[]'
 
 # Return the list of targets depending on the current OS and architecture
 listarch-%: check-reqs
-	@set -x; make --silent showarch-$* | jq -r '.target | keys[]'
+	@set -x; $(MAKE) --silent showarch-$* | jq -r '.target | keys[]'
 
 # Return the list of targets of a specific bake group
 listgroup-%: check-reqs
-	@set -x; make --silent show-$* | jq -r '.group | keys[]' | grep -v -e $* -e default
+	@set -x; $(MAKE) --silent show-$* | jq -r '.group | keys[]' | grep -v -e $* -e default
 
 # Ensure bats exists in the current folder
 bats:
@@ -143,7 +143,7 @@ target:
 
 # Publish all targets corresponding to the current OS
 publish:
-	@set -x; make --silent publish-$(OS)
+	@set -x; $(MAKE) --silent publish-$(OS)
 
 # Publish a specific "target" (can be a docker bake group)
 publish-%: target show-%
@@ -170,20 +170,20 @@ test-%: prepare-test
 # Check that the image exists in the manifest
 	@$(call check_image,$*)
 # Ensure that the image is built
-	@set -x; make --silent build-$*
-	@set -x; make --silent _test-dispatch TARGET=$*
+	@set -x; $(MAKE) --silent build-$*
+	@set -x; $(MAKE) --silent _test-dispatch TARGET=$*
 
 # Dispatch the test depending if it's a bake target or a group
 _test-dispatch:
-	@set -x; if make --silent listgroup-linux | grep -w "$(TARGET)" >/dev/null 2>&1; then \
-		make --silent _test-group TARGET=$(TARGET); \
+	@set -x; if $(MAKE) --silent listgroup-linux | grep -w "$(TARGET)" >/dev/null 2>&1; then \
+		$(MAKE) --silent _test-group TARGET=$(TARGET); \
 	else \
-		make --silent _test-image TARGET=$(TARGET); \
+		$(MAKE) --silent _test-image TARGET=$(TARGET); \
 	fi
 
 # Test a group by iterating on its targets
 _test-group:
-	@set -x; make --silent list-$(TARGET) | while read image; do make --silent test-$$image; done
+	@set -x; $(MAKE) --silent list-$(TARGET) | while read image; do $(MAKE) --silent test-$$image; done
 
 # Test an image
 _test-image:
@@ -201,4 +201,4 @@ endif
 
 # Test all targets depending on the current OS and architecture
 test:
-	@set -x; make --silent test-$(OS)
+	@set -x; $(MAKE) --silent test-$(OS)


### PR DESCRIPTION
This change uses `pretty` formatter when runnning `bats` locally (adds colors and a nice tests result like "4 tests, 0 failures in 16 seconds"), and uses `$(MAKE)` instead of `make` for recursive calls.

Ref:
- https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html

### Testing done

`make test`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
