### PR TITLE
chore(windows): switch Adoptium installation to ZIP archive instead of MSI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' require
 ## Check if a given image or group exists in the current manifest docker-bake.hcl
 check_image = $(MAKE) --silent list listgroup-all | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image or group '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of '$(MAKE) list' or '$(MAKE) listgroup-all'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
-bake_base_cli := docker buildx bake --file docker-bake.hcl
+bake_base_cli := docker buildx bake --file docker-bake.hcl --file docker-bake.override.json
 ## Command to be used on build (only)
 bake_cli := $(bake_base_cli) --load
 ## Default bake target

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ make list
 + make --silent show
 + jq --arg arch linux/arm64 '.target |= with_entries(select(.value.platforms | index($arch)))'
 + make --silent show-all
-+ docker buildx bake --file docker-bake.hcl --progress=quiet --print all
++ docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --progress=quiet --print all
 + jq
 agent_alpine_jdk21
 agent_alpine_jdk25
@@ -62,7 +62,7 @@ To list them all:
 $ make list-all
 + make --silent show-all
 + jq -r '.target | keys[]'
-+ docker buildx bake --file docker-bake.hcl --progress=quiet --print all
++ docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --progress=quiet --print all
 + jq
 agent_alpine_jdk17
 agent_alpine_jdk21
@@ -118,7 +118,7 @@ $ OS=windows ARCH=amd64 make list
 + make --silent show
 + jq --arg arch windows/amd64 '.target |= with_entries(select(.value.platforms | index($arch)))'
 + make --silent show-all
-+ docker buildx bake --file docker-bake.hcl --progress=quiet --print all
++ docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --progress=quiet --print all
 + jq
 agent_nanoserver-ltsc2019_jdk17
 agent_nanoserver-ltsc2019_jdk21
@@ -208,7 +208,7 @@ Note that to see all tags created on publication, you'll have to set `ON_TAG` to
 ```json
 $ make show
 + make --silent show-all
-+ docker buildx bake --file docker-bake.hcl --progress=quiet --print all
++ docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --progress=quiet --print all
 + jq
 {
   "group": {
@@ -539,7 +539,7 @@ Note: you can generate this docker compose file from docker-bake.hcl yourself wi
 # - Convert with yq to the format expected by docker compose
 # - Store the result in the docker compose file
 
-$ docker buildx bake --progress=quiet --file=docker-bake.hcl windows --print \
+$ docker buildx bake --progress=quiet --file=docker-bake.hcl --file docker-bake.override.json windows --print \
     | yq --prettyPrint '.target[] | del(.output) | {(. | key): {"image": .tags[0], "build": .}}' | yq '{"services": .}' \
     > build-windows_mybuild.yaml
 ```

--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ if [[ "${target}" = "publish" ]] ; then
     export BUILD_NUMBER=$build_number
   fi
   make show
-  docker buildx bake --push --file docker-bake.hcl linux
+  docker buildx bake --push --file docker-bake.hcl --file docker-bake.override.json linux
   exit_result=$?
 fi
 exit_if_error

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -154,10 +154,10 @@ target "nanoserver" {
   context    = "."
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
-    JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     VERSION               = REMOTING_VERSION
     WINDOWS_VERSION_TAG   = windows_version
+    JAVA_ZIP_URL = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
   }
   target    = type
   tags      = windows_tags(type, jdk, "nanoserver-${windows_version}")
@@ -175,10 +175,10 @@ target "windowsservercore" {
   context    = "."
   args = {
     JAVA_HOME             = "C:/openjdk-${jdk}"
-    JAVA_VERSION          = "${replace(javaversion(jdk), "_", "+")}"
     TOOLS_WINDOWS_VERSION = "${toolsversion(windows_version)}"
     VERSION               = REMOTING_VERSION
     WINDOWS_VERSION_TAG   = windows_version
+    JAVA_ZIP_URL = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
   }
   target    = type
   tags      = windows_tags(type, jdk, "windowsservercore-${windows_version}")

--- a/docker-bake.override.json
+++ b/docker-bake.override.json
@@ -1,0 +1,15 @@
+{
+  "variable": {
+    "jdk_installer_urls": {
+      "default": {
+        "windows": {
+          "amd64": {
+            "17": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip",
+            "21": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.zip",
+            "25": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip"
+          }
+        }
+      }
+    }
+  }
+}

--- a/make.ps1
+++ b/make.ps1
@@ -89,7 +89,6 @@ function Test-Image {
     $items = $AgentTypeAndImageName.Split('|')
     $agentType = $items[0]
     $imageName = $items[1] -replace 'docker.io/', ''
-    $javaVersion = $items[2]
     $imageNameItems = $imageName.Split(':')
     $imageTag = $imageNameItems[1]
 
@@ -97,7 +96,6 @@ function Test-Image {
 
     $env:IMAGE_NAME = $imageName
     $env:VERSION = "$RemotingVersion"
-    $env:JAVA_VERSION = "$javaVersion"
 
     $targetPath = '.\target\{0}\{1}' -f $agentType, $imageTag
     if (Test-Path $targetPath) {
@@ -117,7 +115,6 @@ function Test-Image {
 
     Remove-Item env:\IMAGE_NAME
     Remove-Item env:\VERSION
-    Remove-Item env:\JAVA_VERSION
 
     return $failed
 }
@@ -156,7 +153,7 @@ function Initialize-DockerComposeFile {
     # - Use docker buildx bake to output image definitions from the "<windowsFlavor>" bake target
     # - Convert with yq to the format expected by docker compose
     # - Store the result in the docker compose file
-    docker buildx bake --progress=quiet --file=docker-bake.hcl $windowsFlavor --print |
+    docker buildx bake --progress=quiet --file=docker-bake.hcl --file docker-bake.override.json $windowsFlavor --print |
         yq --prettyPrint $yqMainQuery |
         yq $yqServicesQuery |
         Out-File -FilePath $DockerComposeFile
@@ -233,7 +230,7 @@ foreach($agentType in $AgentTypes) {
             $testFailed = $false
             $imageDefinitions = Invoke-Expression "$baseDockerCmd config" | yq --unwrapScalar --output-format json '.services' | ConvertFrom-Json
             foreach ($imageDefinition in $imageDefinitions.PSObject.Properties) {
-                $testFailed = $testFailed -or (Test-Image ('{0}|{1}|{2}' -f $agentType, $imageDefinition.Value.image, $imageDefinition.Value.build.args.JAVA_VERSION))
+                $testFailed = $testFailed -or (Test-Image ('{0}|{1}' -f $agentType, $imageDefinition.Value.image))
             }
 
             # Fail if any test failures

--- a/tests/agent.Tests.ps1
+++ b/tests/agent.Tests.ps1
@@ -2,9 +2,9 @@ Import-Module -DisableNameChecking -Force $PSScriptRoot/test_helpers.psm1
 
 $global:IMAGE_NAME = Get-EnvOrDefault 'IMAGE_NAME' '' # Ex: jenkins/agent:ltsc2022
 $global:VERSION = Get-EnvOrDefault 'VERSION' ''
-$global:JAVA_VERSION = Get-EnvOrDefault 'JAVA_VERSION' ''
+$global:JAVA_ZIP_URL = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip'
 
-Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Remoting $global:VERSION and Java $global:JAVA_VERSION"
+Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Remoting $global:VERSION"
 
 $imageItems = $global:IMAGE_NAME.Split(':')
 $GLOBAL:IMAGE_TAG = $imageItems[1]
@@ -156,7 +156,7 @@ Describe "[$global:IMAGE_NAME] can be built with custom build arguments" {
     BeforeAll {
         Push-Location -StackName 'agent' -Path "$PSScriptRoot/.."
 
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --target agent --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"JAVA_VERSION=${global:JAVA_VERSION}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:WINDOWSVERSIONFALLBACKTAG}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" --tag ${global:IMAGE_NAME} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --target agent --build-arg `"VERSION=${global:TEST_VERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg `"TOOLS_WINDOWS_VERSION=${global:WINDOWSVERSIONFALLBACKTAG}`" --build-arg `"user=${global:TEST_USER}`" --build-arg `"AGENT_WORKDIR=${global:TEST_AGENT_WORKDIR}`" --tag ${global:IMAGE_NAME} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run -d -it --name $global:CONTAINERNAME -P $global:IMAGE_NAME $global:CONTAINERSHELL"

--- a/tests/inbound-agent.Tests.ps1
+++ b/tests/inbound-agent.Tests.ps1
@@ -2,9 +2,9 @@ Import-Module -DisableNameChecking -Force $PSScriptRoot/test_helpers.psm1
 
 $global:IMAGE_NAME = Get-EnvOrDefault 'IMAGE_NAME' '' # Ex: jenkins/inbound-agent:ltsc2022
 $global:VERSION = Get-EnvOrDefault 'VERSION' ''
-$global:JAVA_VERSION = Get-EnvOrDefault 'JAVA_VERSION' ''
+$global:JAVA_ZIP_URL = 'https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip'
 
-Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Remoting $global:VERSION and Java $global:JAVA_VERSION"
+Write-Host "= TESTS: Preparing $global:IMAGE_NAME with Remoting $global:VERSION"
 
 $imageItems = $global:IMAGE_NAME.Split(':')
 $GLOBAL:IMAGE_TAG = $imageItems[1]
@@ -38,7 +38,7 @@ BuildNcatImage($global:WINDOWSVERSIONTAG)
 
 Describe "[$global:IMAGE_NAME] build image" {
     It 'builds image' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:VERSION}`" --build-arg `"JAVA_VERSION=${global:JAVA_VERSION}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${global:VERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --tag=${global:IMAGE_TAG} --file ./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
     }
 }
@@ -127,7 +127,7 @@ Describe "[$global:IMAGE_NAME] custom build args" {
     }
 
     It 'builds image with arguments' {
-        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${TEST_VERSION}`" --build-arg `"JAVA_VERSION=${global:JAVA_VERSION}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg WINDOWS_FLAVOR=${global:WINDOWSFLAVOR} --build-arg CONTAINER_SHELL=${global:CONTAINERSHELL} --tag=${customImageName} --file=./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
+        $exitCode, $stdout, $stderr = Run-Program 'docker' "build --build-arg `"VERSION=${TEST_VERSION}`" --build-arg `"JAVA_ZIP_URL=${global:JAVA_ZIP_URL}`" --build-arg `"JAVA_HOME=C:\openjdk-${global:JAVAMAJORVERSION}`" --build-arg `"WINDOWS_VERSION_TAG=${global:WINDOWSVERSIONTAG}`" --build-arg WINDOWS_FLAVOR=${global:WINDOWSFLAVOR} --build-arg CONTAINER_SHELL=${global:CONTAINERSHELL} --tag=${customImageName} --file=./windows/${global:WINDOWSFLAVOR}/Dockerfile ."
         $exitCode | Should -Be 0
 
         $exitCode, $stdout, $stderr = Run-Program 'docker' "run --detach --tty --name $global:CONTAINERNAME $customImageName -Cmd $global:CONTAINERSHELL"

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -72,18 +72,6 @@ targets:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
-  setJDK17VersionWindows:
-    name: "Bump JDK17 default ARG version in Windows images"
-    kind: dockerfile
-    sourceid: lastVersion
-    spec:
-      files:
-        - windows/nanoserver/Dockerfile
-        - windows/windowsservercore/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
   setJDK17VersionReadme:
     name: "Bump JDK17 version in README.md file"
     kind: file

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -29,14 +29,16 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=17.0.19+10
-RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
-    $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
-    $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION ; `
-    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  "INSTALLDIR=C:\openjdk-${javaMajorVersion}" -Wait -Passthru ; `
-    $proc.WaitForExit() ; `
-    Remove-Item -Path C:\temp -Recurse | Out-Null
+ARG JAVA_HOME="C:\openjdk-17"
+ARG JAVA_ZIP_URL="Provided by docker-bake.hcl"
+ARG jdkTemp="C:\jdktemp"
+ARG localArchive="${jdkTemp}\jdk.zip"
+RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
+    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive ; `
+    Expand-Archive -Path $env:localArchive -DestinationPath $env:jdkTemp ; `
+    $expandedDir = Get-ChildItem -Path $env:jdkTemp -Directory | Where-Object { $_.Name -like 'jdk*' } ; `
+    Move-Item -Path $expandedDir.FullName -Destination $env:JAVA_HOME -Force ; `
+    Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 FROM mcr.microsoft.com/powershell:nanoserver-"${TOOLS_WINDOWS_VERSION}" AS pwsh-source
 

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -29,14 +29,16 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS jdk-core
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=17.0.19+10
-RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
-    $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
-    $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION ; `
-    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  "INSTALLDIR=C:\openjdk-${javaMajorVersion}" -Wait -Passthru ; `
-    $proc.WaitForExit() ; `
-    Remove-Item -Path C:\temp -Recurse | Out-Null
+ARG JAVA_HOME="C:\openjdk-17"
+ARG JAVA_ZIP_URL="Provided by docker-bake.hcl"
+ARG jdkTemp="C:\jdktemp"
+ARG localArchive="${jdkTemp}\jdk.zip"
+RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
+    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive ; `
+    Expand-Archive -Path $env:localArchive -DestinationPath $env:jdkTemp ; `
+    $expandedDir = Get-ChildItem -Path $env:jdkTemp -Directory | Where-Object { $_.Name -like 'jdk*' } ; `
+    Move-Item -Path $expandedDir.FullName -Destination $env:JAVA_HOME -Force ; `
+    Remove-Item -Path $env:jdkTemp -Recurse | Out-Null
 
 ## Agent image target
 FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION_TAG}" AS agent


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/docker-agents/issues/1265

This PR changes the installation method of Adoptium inside our Docker containers.

- Only for Windows! Linux would be next but let's go step by step.
- No GPG verification (yet): we don't do it today but it could  be a great improvement (https://adoptium.net/installation/gpg-verification)
- Introduces a new JSON `docker-bake.override.json` file as it's easier to keep up to date with tools like updatecli or renovabot. Had to add it to all calls to `docker buildx bake` CLI (even Linux in advance to avoid forgetting about it).
  - I guess we could remove all `--file` flags for buildx bake and let https://docs.docker.com/build/bake/reference/#file-format do its job. Worth another PR for this.
- Removes the `JAVA_VERSION`  build argument (unneeded anymore and not passed to end user as `ENV` so no user facing change)
  - Includes test updates to handle this change

### Testing done

- Was able to get my build stuck on my Windows 11 machine (building the 2019 images) as preliminary
- Ran locally the build: passed without being stuck
- Locally running tests: java version are 👍 (but stuck on nmap)
- Checking ci.jenkins.io: same behavior
