### PR TITLE
chore(updatecli): add `pwsh` manifest

### DIFF
--- a/updatecli/updatecli.d/pwsh.yml
+++ b/updatecli/updatecli.d/pwsh.yml
@@ -1,0 +1,57 @@
+name: Bump `pwsh` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get latest `pwsh` version
+    spec:
+      owner: PowerShell
+      repository: PowerShell
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: "v"
+
+targets:
+  setPwshVersionNanoserver:
+    name: Update `pwsh` version in nanoserver Dockerfile
+    kind: dockerfile
+    spec:
+      file: windows/nanoserver/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: PWSH_VERSION
+    scmid: default
+  setPwshVersionWindowsTests:
+    name: Update `pwsh` version in Windows tests
+    kind: file
+    spec:
+      file: tests/agent.Tests.ps1
+      matchpattern: >
+        global:PWSHVERSION =(.*)
+      replacepattern: >
+        global:PWSHVERSION = '{{ source "lastVersion" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `pwsh` version to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - pwsh
+        - nanoserver


### PR DESCRIPTION
Follow-up of:
- #1282 

### Testing done

<details><summary>updatecli diff --config updatecli/updatecli.d/pwsh.yml --values updatecli/values.github-action.yaml</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/pwsh.yml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


#######################
# BUMP `PWSH` VERSION #
#######################

Pipeline ID	: 6bf05b58c630f8b71de576055712e2cfb3627ac6ec1a735d6e14903c4c16b634
Dry Run		: enabled

source: lastVersion
-------------------

Searching for version matching pattern "latest"
✔ GitHub release version "v7.6.4" found matching pattern "latest" of kind "latest"
[transformers]
✔ Result correctly transformed from "v7.6.4" to "7.6.4"

target: setPwshVersionWindowsTests
----------------------------------

Repository	: github.com/jenkinsci/docker-agent@master

"tests/agent.Tests.ps1" updated with [dry run] content "global:PWSHVERSION = '7.6.4'\n"

--- tests/agent.Tests.ps1
+++ tests/agent.Tests.ps1
@@ -25,7 +25,7 @@
 }
 
 $global:GITLFSVERSION = '3.7.1'
-$global:PWSHVERSION = '7.3.9'
+$global:PWSHVERSION = '7.6.4'
 
 # # Uncomment to help debugging when working on this script
 # Write-Host "= DEBUG: global vars"


⚠ - 1 file(s) updated with "global:PWSHVERSION = '7.6.4'\n":
	* tests/agent.Tests.ps1

target: setPwshVersionNanoserver
--------------------------------

Repository	: github.com/jenkinsci/docker-agent@master

⚠ The line #42, matched by the keyword "ARG" and the matcher "PWSH_VERSION", is changed from "ARG PWSH_VERSION=7.3.9" to "ARG PWSH_VERSION=7.6.4".
⚠ - changed lines [42] of file "windows/nanoserver/Dockerfile"


ACTIONS
========

---
Pipeline Name	: Bump `pwsh` version
Pipeline ID	: 6bf05b58c630f8b71de576055712e2cfb3627ac6ec1a735d6e14903c4c16b634
Dry run		: true
Repository	: github.com/jenkinsci/docker-agent@master
Action		: Bump `pwsh` version to 7.6.4
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Bump `pwsh` version:
	Source:
		✔ [lastVersion] Get latest `pwsh` version
	Target:
		⚠ [setPwshVersionNanoserver] Update `pwsh` version in nanoserver Dockerfile
		      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)
		⚠ [setPwshVersionWindowsTests] Update `pwsh` version in Windows tests
		      * Repository: https://github.com/jenkinsci/docker-agent.git (branch: master)


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
